### PR TITLE
Add AutoMapper component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
     "replace": {
         "symfony/asset": "self.version",
         "symfony/asset-mapper": "self.version",
+        "symfony/automapper": "self.version",
         "symfony/browser-kit": "self.version",
         "symfony/cache": "self.version",
         "symfony/clock": "self.version",
@@ -155,7 +156,8 @@
         "twig/inky-extra": "^2.12|^3",
         "twig/markdown-extra": "^2.12|^3",
         "web-token/jwt-checker": "^3.1",
-        "web-token/jwt-signature-algorithm-ecdsa": "^3.1"
+        "web-token/jwt-signature-algorithm-ecdsa": "^3.1",
+        "moneyphp/money": "^4.1"
     },
     "conflict": {
         "ext-psr": "<1.1|>=2",

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -26,6 +26,8 @@ class UnusedTagsPass implements CompilerPassInterface
         'asset_mapper.importmap.resolver',
         'assets.package',
         'auto_alias',
+        'automapper.cache_warmer_loader',
+        'automapper.transformer_factory',
         'cache.pool',
         'cache.pool.clearer',
         'cache.taggable',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -18,6 +18,7 @@ use Symfony\Bundle\FullStack;
 use Symfony\Component\Asset\Package;
 use Symfony\Component\AssetMapper\AssetMapper;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapManager;
+use Symfony\Component\AutoMapper\AutoMapper;
 use Symfony\Component\Cache\Adapter\DoctrineAdapter;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
@@ -178,6 +179,7 @@ class Configuration implements ConfigurationInterface
         $this->addHtmlSanitizerSection($rootNode, $enableIfStandalone);
         $this->addWebhookSection($rootNode, $enableIfStandalone);
         $this->addRemoteEventSection($rootNode, $enableIfStandalone);
+        $this->addAutoMapperSection($rootNode, $enableIfStandalone);
 
         return $treeBuilder;
     }
@@ -2441,6 +2443,35 @@ class Configuration implements ConfigurationInterface
                                         ->info('The maximum length allowed for the sanitized input.')
                                         ->defaultValue(0)
                                     ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addAutoMapperSection(ArrayNodeDefinition $rootNode, callable $enableIfStandalone): void
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('automapper')
+                    ->info('AutoMapper configuration')
+                    ->{$enableIfStandalone('symfony/automapper', AutoMapper::class)}()
+                    ->children()
+                        ->booleanNode('normalizer')->defaultFalse()->end()
+                        ->scalarNode('name_converter')->defaultNull()->end()
+                        ->scalarNode('cache_dir')->defaultValue('%kernel.cache_dir%/automapper')->end()
+                        ->scalarNode('date_time_format')->defaultValue(\DateTimeInterface::RFC3339)->end()
+                        ->scalarNode('mapper_prefix')->defaultValue('Symfony_Mapper_')->end()
+                        ->booleanNode('hot_reload')->defaultValue($this->debug)->end()
+                        ->booleanNode('allow_readonly_target_to_populate')->defaultFalse()->end()
+                        ->arrayNode('warmup')
+                            ->arrayPrototype()
+                                ->children()
+                                    ->scalarNode('source')->defaultValue('array')->end()
+                                    ->scalarNode('target')->defaultValue('array')->end()
                                 ->end()
                             ->end()
                         ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -23,6 +23,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TestServiceConta
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TestServiceContainerWeakRefPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\UnusedTagsPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\WorkflowGuardListenerPass;
+use Symfony\Component\AutoMapper\DependencyInjection\AutoMapperPass;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\ChainAdapter;
@@ -172,6 +173,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new RegisterReverseContainerPass(true));
         $container->addCompilerPass(new RegisterReverseContainerPass(false), PassConfig::TYPE_AFTER_REMOVING);
         $container->addCompilerPass(new RemoveUnusedSessionMarshallingHandlerPass());
+        $this->addCompilerPassIfExists($container, AutoMapperPass::class);
 
         if ($container->getParameter('kernel.debug')) {
             $container->addCompilerPass(new AddDebugLogProcessorPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 2);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/automapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/automapper.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\AutoMapper\AutoMapper;
+use Symfony\Component\AutoMapper\AutoMapperInterface;
+use Symfony\Component\AutoMapper\AutoMapperRegistryInterface;
+use Symfony\Component\AutoMapper\CacheWarmup\CacheWarmer;
+use Symfony\Component\AutoMapper\CacheWarmup\ConfigurationCacheWarmerLoader;
+use Symfony\Component\AutoMapper\Extractor\FromSourceMappingExtractor;
+use Symfony\Component\AutoMapper\Extractor\FromTargetMappingExtractor;
+use Symfony\Component\AutoMapper\Extractor\SourceTargetMappingExtractor;
+use Symfony\Component\AutoMapper\Generator\Generator;
+use Symfony\Component\AutoMapper\Loader\ClassLoaderInterface;
+use Symfony\Component\AutoMapper\Loader\FileLoader;
+use Symfony\Component\AutoMapper\MapperGeneratorMetadataFactory;
+use Symfony\Component\AutoMapper\MapperGeneratorMetadataFactoryInterface;
+use Symfony\Component\AutoMapper\MapperGeneratorMetadataRegistryInterface;
+use Symfony\Component\AutoMapper\Normalizer\AutoMapperNormalizer;
+use Symfony\Component\AutoMapper\Transformer\ArrayTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\BuiltinTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\ChainTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\DateTimeTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\EnumTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\MultipleTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\NullableTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\ObjectTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\SymfonyUidTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\TransformerFactoryInterface;
+use Symfony\Component\AutoMapper\Transformer\UniqueTypeTransformerFactory;
+use Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set('automapper', AutoMapper::class)
+            ->args([
+                service(ClassLoaderInterface::class),
+                service(MapperGeneratorMetadataFactoryInterface::class),
+            ])
+        ->alias(AutoMapperInterface::class, 'automapper')
+        ->alias(AutoMapperRegistryInterface::class, 'automapper')
+        ->alias(MapperGeneratorMetadataRegistryInterface::class, 'automapper')
+
+        ->set('automapper.extractor.source_target', SourceTargetMappingExtractor::class)
+            ->args([
+                service('property_info'),
+                service('property_info.reflection_extractor'),
+                service('property_info.reflection_extractor'),
+                service('automapper.transformer_factory.chain'),
+            ])
+        ->set('automapper.extractor.from_target', FromTargetMappingExtractor::class)
+            ->args([
+                service('property_info'),
+                service('property_info.reflection_extractor'),
+                service('property_info.reflection_extractor'),
+                service('automapper.transformer_factory.chain'),
+                service(ClassMetadataFactoryInterface::class),
+            ])
+        ->set('automapper.extractor.from_source', FromSourceMappingExtractor::class)
+            ->args([
+                service('property_info'),
+                service('property_info.reflection_extractor'),
+                service('property_info.reflection_extractor'),
+                service('automapper.transformer_factory.chain'),
+                service(ClassMetadataFactoryInterface::class),
+            ])
+
+        ->set('automapper.metadata.generator', MapperGeneratorMetadataFactory::class)
+            ->args([
+                service('automapper.extractor.source_target'),
+                service('automapper.extractor.from_source'),
+                service('automapper.extractor.from_target'),
+                param('automapper.mapper_prefix'),
+                true,
+                param('automapper.datetime_format'),
+            ])
+        ->alias(MapperGeneratorMetadataFactoryInterface::class, 'automapper.metadata.generator')
+
+        ->set('automapper.generator', Generator::class)
+            ->args([null, service(ClassDiscriminatorResolverInterface::class), false])
+
+        ->set('automapper.loader.file', FileLoader::class)
+            ->args([
+                service('automapper.generator'),
+                param('automapper.cache_dir'),
+                param('kernel.debug'),
+            ])
+        ->alias(ClassLoaderInterface::class, 'automapper.loader.file')
+
+        ->set('automapper.cache_warmer', CacheWarmer::class)
+            ->args([
+                service(ClassLoaderInterface::class),
+                service(AutoMapperRegistryInterface::class),
+                service(MapperGeneratorMetadataFactoryInterface::class),
+                tagged_iterator('automapper.cache_warmer_loader'),
+            ])
+            ->tag('kernel.cache_warmer')
+        
+        ->set('automapper.configuration_cache_warmer', ConfigurationCacheWarmerLoader::class)
+            ->args([[]])
+            ->tag('automapper.cache_warmer_loader')
+
+        ->set('automapper.normalizer', AutoMapperNormalizer::class)
+            ->args([service('automapper')])
+
+        ->set('automapper.transformer_factory.chain', ChainTransformerFactory::class)
+            ->args([[]])
+        ->alias(TransformerFactoryInterface::class, 'automapper.transformer_factory.chain')
+
+        ->set('automapper.transformer_factory.symfony_uid', SymfonyUidTransformerFactory::class)
+
+        ->set('automapper.transformer_factory.multiple', MultipleTransformerFactory::class)
+            ->tag('automapper.transformer_factory', ['priority' => 1002])
+        ->set('automapper.transformer_factory.nullable', NullableTransformerFactory::class)
+            ->tag('automapper.transformer_factory', ['priority' => 1001])
+        ->set('automapper.transformer_factory.unique_type', UniqueTypeTransformerFactory::class)
+            ->tag('automapper.transformer_factory', ['priority' => 1000])
+        ->set('automapper.transformer_factory.object', ObjectTransformerFactory::class)
+            ->args([service('automapper')])
+            ->tag('automapper.transformer_factory',  ['priority' => -1000])
+        ->set('automapper.transformer_factory.enum', EnumTransformerFactory::class)
+            ->tag('automapper.transformer_factory',  ['priority' => -1001])
+        ->set('automapper.transformer_factory.datetime', DateTimeTransformerFactory::class)
+            ->tag('automapper.transformer_factory', ['priority' => -1001])
+        ->set('automapper.transformer_factory.builtin', BuiltinTransformerFactory::class)
+            ->tag('automapper.transformer_factory', ['priority' => -1002])
+        ->set('automapper.transformer_factory.array', ArrayTransformerFactory::class)
+            ->tag('automapper.transformer_factory', ['priority' => -1003])
+    ;
+};

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -782,6 +782,17 @@ class ConfigurationTest extends TestCase
             'remote-event' => [
                 'enabled' => false,
             ],
+            'automapper' => [
+                'enabled' => true,
+                'normalizer' => false,
+                'name_converter' => null,
+                'cache_dir' => '%kernel.cache_dir%/automapper',
+                'date_time_format' => \DateTimeInterface::ATOM,
+                'mapper_prefix' => 'Symfony_Mapper_',
+                'hot_reload' => true,
+                'allow_readonly_target_to_populate' => false,
+                'warmup' => [],
+            ],
         ];
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/AutoMapper/Bar.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/AutoMapper/Bar.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\AutoMapper;
+
+class Bar
+{
+    public int $id;
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/AutoMapper/Foo.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/AutoMapper/Foo.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\AutoMapper;
+
+class Foo
+{
+    /**
+     * @var Bar[]
+     */
+    public array $bars;
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutoMapperTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutoMapperTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\AutoMapper\Bar;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\AutoMapper\Foo;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class AutoMapperTest extends AbstractWebTestCase
+{
+    public function testMapArrayOfObject()
+    {
+        static::bootKernel(['test_case' => 'AutoMapper']);
+        $cacheDirectory = static::getContainer()->getParameter('automapper.cache_dir');
+
+        $this->assertFileExists($cacheDirectory . '/Symfony_Mapper_array_Symfony_Bundle_FrameworkBundle_Tests_Fixtures_AutoMapper_Foo.php');
+        $this->assertFileExists($cacheDirectory . '/Symfony_Mapper_array_Symfony_Bundle_FrameworkBundle_Tests_Fixtures_AutoMapper_Bar.php');
+
+        $result = static::getContainer()->get('automapper.alias')->map(['bars' => [['id' => 1], ['id' => 2]]], Foo::class);
+
+        $bar1 = new Bar();
+        $bar1->id = 1;
+        $bar2 = new Bar();
+        $bar2->id = 2;
+
+        $expected = new Foo();
+        $expected->bars = [$bar1, $bar2];
+
+        $this->assertEquals($expected, $result);
+    }
+}
+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AutoMapper/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AutoMapper/bundles.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+
+return [
+    new FrameworkBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AutoMapper/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AutoMapper/config.yml
@@ -1,0 +1,16 @@
+imports:
+    - { resource: ../config/default.yml }
+
+framework:
+    automapper: 
+        enabled: true
+        warmup:
+            - {source: 'array', target: 'Symfony\Bundle\FrameworkBundle\Tests\Fixtures\AutoMapper\Foo'}
+            - {target: 'Symfony\Bundle\FrameworkBundle\Tests\Fixtures\AutoMapper\Bar'}
+    serializer: { enabled: true }
+    property_info: { enabled: true }
+
+services:
+    automapper.alias:
+        alias: automapper
+        public: true

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -37,6 +37,7 @@
         "seld/jsonlint": "^1.10",
         "symfony/asset": "^6.4|^7.0",
         "symfony/asset-mapper": "^6.4|^7.0",
+        "symfony/automapper": "^7.0",
         "symfony/browser-kit": "^6.4|^7.0",
         "symfony/console": "^6.4|^7.0",
         "symfony/clock": "^6.4|^7.0",

--- a/src/Symfony/Component/AutoMapper/.gitattributes
+++ b/src/Symfony/Component/AutoMapper/.gitattributes
@@ -1,0 +1,4 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Component/AutoMapper/.gitignore
+++ b/src/Symfony/Component/AutoMapper/.gitignore
@@ -1,0 +1,4 @@
+vendor/
+composer.lock
+phpunit.xml
+Tests/cache/

--- a/src/Symfony/Component/AutoMapper/AutoMapper.php
+++ b/src/Symfony/Component/AutoMapper/AutoMapper.php
@@ -1,0 +1,254 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Symfony\Component\AutoMapper\Exception\NoMappingFoundException;
+use Symfony\Component\AutoMapper\Extractor\FromSourceMappingExtractor;
+use Symfony\Component\AutoMapper\Extractor\FromTargetMappingExtractor;
+use Symfony\Component\AutoMapper\Extractor\SourceTargetMappingExtractor;
+use Symfony\Component\AutoMapper\Generator\Generator;
+use Symfony\Component\AutoMapper\Loader\ClassLoaderInterface;
+use Symfony\Component\AutoMapper\Loader\EvalLoader;
+use Symfony\Component\AutoMapper\Transformer\ArrayTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\BuiltinTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\ChainTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\DateTimeTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\EnumTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\MultipleTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\NullableTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\ObjectTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\SymfonyUidTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\UniqueTypeTransformerFactory;
+use PhpParser\ParserFactory;
+use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
+use Symfony\Component\Uid\AbstractUid;
+
+/**
+ * Maps a source data structure (object or array) to a target one.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class AutoMapper implements AutoMapperInterface, AutoMapperRegistryInterface, MapperGeneratorMetadataRegistryInterface
+{
+    /** @var GeneratedMapper[] */
+    private array $mapperRegistry = [];
+
+    /** @var array<string, array<string, MapperGeneratorMetadataInterface>> */
+    private array $metadata = [];
+
+    public function __construct(
+        private readonly ClassLoaderInterface $classLoader,
+        private readonly ?MapperGeneratorMetadataFactoryInterface $mapperConfigurationFactory = null,
+    ) {
+    }
+
+    public function map(null|array|object $source, string|array|object $target, array $context = []): null|array|object
+    {
+        $guessedSource = $guessedTarget = null;
+
+        if (null === $source) {
+            return null;
+        }
+
+        if (\is_object($source)) {
+            $guessedSource = $source::class;
+        } elseif (\is_array($source)) {
+            $guessedSource = 'array';
+        }
+
+        if (null === $guessedSource) {
+            throw new NoMappingFoundException('Cannot map this value, source is neither an object or an array.');
+        }
+
+        if (\is_object($target)) {
+            $guessedTarget = $target::class;
+            $context[MapperContext::TARGET_TO_POPULATE] = $target;
+        } elseif (\is_array($target)) {
+            $guessedTarget = 'array';
+            $context[MapperContext::TARGET_TO_POPULATE] = $target;
+        } elseif (\is_string($target)) {
+            $guessedTarget = $target;
+        }
+
+        if ('array' === $guessedSource && 'array' === $guessedTarget) {
+            throw new NoMappingFoundException('Cannot map this value, both source and target are array.');
+        }
+
+        return $this->getMapper($guessedSource, $guessedTarget)->map($source, $context);
+    }
+
+    public function getMapper(string $source, string $target): MapperInterface
+    {
+        $metadata = $this->getMetadata($source, $target);
+
+        if (null === $metadata) {
+            throw new NoMappingFoundException('No mapping found for source '.$source.' and target '.$target);
+        }
+
+        $className = $metadata->getMapperClassName();
+
+        if (\array_key_exists($className, $this->mapperRegistry)) {
+            return $this->mapperRegistry[$className];
+        }
+
+        if (!class_exists($className)) {
+            $this->classLoader->loadClass($metadata);
+        }
+
+        $this->mapperRegistry[$className] = new $className();
+        $this->mapperRegistry[$className]->injectMappers($this);
+
+        foreach ($metadata->getCallbacks() as $property => $callback) {
+            $this->mapperRegistry[$className]->addCallback($property, $callback);
+        }
+
+        return $this->mapperRegistry[$className];
+    }
+
+    public function hasMapper(string $source, string $target): bool
+    {
+        return null !== $this->getMetadata($source, $target);
+    }
+
+    public function register(MapperGeneratorMetadataInterface $configuration): void
+    {
+        $this->metadata[$configuration->getSource()][$configuration->getTarget()] = $configuration;
+    }
+
+    public function addMapperConfiguration(MapperConfigurationInterface $mapperConfiguration): void
+    {
+        $metadata = $this->getMetadata($mapperConfiguration->getSource(), $mapperConfiguration->getTarget());
+        $mapperConfiguration->process($metadata);
+    }
+
+    public function getMetadata(string $source, string $target): ?MapperGeneratorMetadataInterface
+    {
+        if (!isset($this->metadata[$source][$target])) {
+            if (null === $this->mapperConfigurationFactory) {
+                return null;
+            }
+
+            $this->register($this->mapperConfigurationFactory->create($this, $source, $target));
+        }
+
+        return $this->metadata[$source][$target];
+    }
+
+    /**
+     * Create an automapper.
+     */
+    public static function create(
+        bool $private = true,
+        ClassLoaderInterface $loader = null,
+        AdvancedNameConverterInterface $nameConverter = null,
+        string $classPrefix = 'Mapper_',
+        bool $attributeChecking = true,
+        bool $autoRegister = true,
+        string $dateTimeFormat = \DateTimeInterface::RFC3339,
+        array $customTransformerFactories = [],
+        bool $allowReadOnlyTargetToPopulate = false
+    ): self {
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+
+        if (null === $loader) {
+            $loader = new EvalLoader(new Generator(
+                (new ParserFactory())->create(ParserFactory::PREFER_PHP7),
+                new ClassDiscriminatorFromClassMetadata($classMetadataFactory),
+                $allowReadOnlyTargetToPopulate,
+            ));
+        }
+
+        $flags = ReflectionExtractor::ALLOW_PUBLIC;
+
+        if ($private) {
+            $flags |= ReflectionExtractor::ALLOW_PROTECTED | ReflectionExtractor::ALLOW_PRIVATE;
+        }
+
+        $reflectionExtractor = new ReflectionExtractor(accessFlags: $flags);
+
+        $phpStanExtractor = new PhpStanExtractor();
+        $propertyInfoExtractor = new PropertyInfoExtractor(
+            [$reflectionExtractor],
+            [$phpStanExtractor, $reflectionExtractor],
+            [$reflectionExtractor],
+            [$reflectionExtractor]
+        );
+
+        $transformerFactory = new ChainTransformerFactory();
+        $sourceTargetMappingExtractor = new SourceTargetMappingExtractor(
+            $propertyInfoExtractor,
+            $reflectionExtractor,
+            $reflectionExtractor,
+            $transformerFactory,
+            $classMetadataFactory
+        );
+
+        $fromTargetMappingExtractor = new FromTargetMappingExtractor(
+            $propertyInfoExtractor,
+            $reflectionExtractor,
+            $reflectionExtractor,
+            $transformerFactory,
+            $classMetadataFactory,
+            $nameConverter
+        );
+
+        $fromSourceMappingExtractor = new FromSourceMappingExtractor(
+            $propertyInfoExtractor,
+            $reflectionExtractor,
+            $reflectionExtractor,
+            $transformerFactory,
+            $classMetadataFactory,
+            $nameConverter
+        );
+
+        $autoMapper = $autoRegister ?
+            new self(
+                $loader,
+                new MapperGeneratorMetadataFactory(
+                    $sourceTargetMappingExtractor,
+                    $fromSourceMappingExtractor,
+                    $fromTargetMappingExtractor,
+                    $classPrefix,
+                    $attributeChecking,
+                    $dateTimeFormat,
+                )
+            )
+            : new self($loader);
+
+        $transformerFactory->addTransformerFactory(new MultipleTransformerFactory());
+        $transformerFactory->addTransformerFactory(new NullableTransformerFactory());
+        $transformerFactory->addTransformerFactory(new UniqueTypeTransformerFactory());
+        $transformerFactory->addTransformerFactory(new DateTimeTransformerFactory());
+        $transformerFactory->addTransformerFactory(new BuiltinTransformerFactory());
+        $transformerFactory->addTransformerFactory(new ArrayTransformerFactory());
+        $transformerFactory->addTransformerFactory(new ObjectTransformerFactory($autoMapper));
+        $transformerFactory->addTransformerFactory(new EnumTransformerFactory());
+
+        foreach ($customTransformerFactories as $factory) {
+            $transformerFactory->addTransformerFactory($factory);
+        }
+
+        if (class_exists(AbstractUid::class)) {
+            $transformerFactory->addTransformerFactory(new SymfonyUidTransformerFactory());
+        }
+
+        return $autoMapper;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/AutoMapperInterface.php
+++ b/src/Symfony/Component/AutoMapper/AutoMapperInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper;
+
+/**
+ * An auto mapper has the role of mapping a source to a target.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+interface AutoMapperInterface
+{
+    /**
+     * Maps data from a source to a target.
+     *
+     * @param array|object|null   $source  Any data object, which may be an object or an array
+     * @param string|array|object $target  To which type of data, or data, the source should be mapped
+     * @param array               $context Mapper context
+     *
+     * @return array|object|null The mapped object
+     */
+    public function map(null|array|object $source, string|array|object $target, array $context = []): null|array|object;
+}

--- a/src/Symfony/Component/AutoMapper/AutoMapperRegistryInterface.php
+++ b/src/Symfony/Component/AutoMapper/AutoMapperRegistryInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper;
+
+/**
+ * Allows to retrieve a mapper.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+interface AutoMapperRegistryInterface
+{
+    /**
+     * Gets a specific mapper for a source type and a target type.
+     *
+     * @param string $source Source type
+     * @param string $target Target type
+     *
+     * @return MapperInterface return associated mapper
+     */
+    public function getMapper(string $source, string $target): MapperInterface;
+
+    /**
+     * Does a specific mapper exist.
+     *
+     * @param string $source Source type
+     * @param string $target Target type
+     */
+    public function hasMapper(string $source, string $target): bool;
+}

--- a/src/Symfony/Component/AutoMapper/CHANGELOG.md
+++ b/src/Symfony/Component/AutoMapper/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+6.3.0
+-----
+
+ * Added the component

--- a/src/Symfony/Component/AutoMapper/CacheWarmup/CacheWarmer.php
+++ b/src/Symfony/Component/AutoMapper/CacheWarmup/CacheWarmer.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\CacheWarmup;
+
+use Symfony\Component\AutoMapper\Loader\FileLoader;
+use Symfony\Component\AutoMapper\MapperGeneratorMetadataFactoryInterface;
+use Symfony\Component\AutoMapper\MapperGeneratorMetadataRegistryInterface;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+/**
+ * @internal
+ */
+final class CacheWarmer implements CacheWarmerInterface
+{
+    private $fileLoader;
+    private $autoMapperRegistry;
+    private $mapperConfigurationFactory;
+    /** @var iterable<CacheWarmerLoaderInterface> */
+    private $cacheWarmerLoaders;
+
+    /** @param iterable<CacheWarmerLoaderInterface> $cacheWarmerLoaders */
+    public function __construct(
+        FileLoader $fileLoader,
+        MapperGeneratorMetadataRegistryInterface $autoMapperRegistry,
+        MapperGeneratorMetadataFactoryInterface $mapperConfigurationFactory,
+        iterable $cacheWarmerLoaders
+    ) {
+        $this->fileLoader = $fileLoader;
+        $this->autoMapperRegistry = $autoMapperRegistry;
+        $this->mapperConfigurationFactory = $mapperConfigurationFactory;
+        $this->cacheWarmerLoaders = $cacheWarmerLoaders;
+    }
+
+    public function isOptional(): bool
+    {
+        return false;
+    }
+
+    public function warmUp($cacheDir): array
+    {
+        $mapperClasses = [];
+
+        foreach ($this->cacheWarmerLoaders as $cacheWarmerLoader) {
+            foreach ($cacheWarmerLoader->loadCacheWarmupData() as $cacheWarmupData) {
+                $mapperClasses[] = $this->fileLoader->saveMapper(
+                    $this->mapperConfigurationFactory->create(
+                        $this->autoMapperRegistry,
+                        $cacheWarmupData->source,
+                        $cacheWarmupData->target
+                    )
+                );
+            }
+        }
+
+        return $mapperClasses;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/CacheWarmup/CacheWarmerLoaderInterface.php
+++ b/src/Symfony/Component/AutoMapper/CacheWarmup/CacheWarmerLoaderInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\CacheWarmup;
+
+interface CacheWarmerLoaderInterface
+{
+    /**
+     * @return iterable<CacheWarmupData>
+     */
+    public function loadCacheWarmupData(): iterable;
+}

--- a/src/Symfony/Component/AutoMapper/CacheWarmup/CacheWarmupData.php
+++ b/src/Symfony/Component/AutoMapper/CacheWarmup/CacheWarmupData.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\CacheWarmup;
+
+use Symfony\Component\AutoMapper\Exception\CacheWarmupDataException;
+
+final class CacheWarmupData
+{
+    public function __construct(
+        public readonly string $source, 
+        public readonly string $target,
+    ) {
+        if (!$this->isValid($source) || !$this->isValid($target)) {
+            throw CacheWarmupDataException::sourceOrTargetDoesNoExist($source, $target);
+        }
+
+        if ($target === $source) {
+            throw CacheWarmupDataException::sourceAndTargetAreEquals($source);
+        }
+    }
+
+    /**
+     * @param array{source: string, target: string} $array
+     */
+    public static function fromArray(array $array): self
+    {
+        return new self($array['source'], $array['target']);
+    }
+
+    private function isValid(string $arrayOrClass): bool
+    {
+        return $arrayOrClass === 'array' || class_exists($arrayOrClass);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/CacheWarmup/ConfigurationCacheWarmerLoader.php
+++ b/src/Symfony/Component/AutoMapper/CacheWarmup/ConfigurationCacheWarmerLoader.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\CacheWarmup;
+
+/**
+ * @internal
+ */
+final class ConfigurationCacheWarmerLoader implements CacheWarmerLoaderInterface
+{
+    private array $mappersToGenerateOnWarmup = [];
+
+    /**
+     * @param list<array{source: string, target: string}> $mappersToGenerateOnWarmup
+     */
+    public function __construct(array $mappersToGenerateOnWarmup = [])
+    {
+        foreach ($mappersToGenerateOnWarmup as $mapperToGenerateOnWarmup) {
+            $this->addMapperToGenerateOnWarmup($mapperToGenerateOnWarmup);
+        }
+    }
+
+    /**
+     * @param array{source: string, target: string} $mapperToGenerateOnWarmup
+     */
+    public function addMapperToGenerateOnWarmup(array $mapperToGenerateOnWarmup): void
+    {
+        $this->mappersToGenerateOnWarmup[] = $mapperToGenerateOnWarmup;
+    }
+
+    public function loadCacheWarmupData(): iterable
+    {
+        foreach ($this->mappersToGenerateOnWarmup as $mapperToGenerate) {
+            yield CacheWarmupData::fromArray($mapperToGenerate);
+        }
+    }
+}

--- a/src/Symfony/Component/AutoMapper/DependencyInjection/AutoMapperPass.php
+++ b/src/Symfony/Component/AutoMapper/DependencyInjection/AutoMapperPass.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class AutoMapperPass implements CompilerPassInterface
+{
+    use PriorityTaggedServiceTrait;
+
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('automapper.transformer_factory.chain')) {
+            return;
+        }
+
+        if (!$container->findTaggedServiceIds('automapper.transformer_factory')) {
+            throw new RuntimeException('You must tag at least one service as "automapper.transformer_factory" to use the "automapper" service.');
+        }
+
+        $chainTransformerFactory = $container->getDefinition('automapper.transformer_factory.chain');
+        foreach ($this->findAndSortTaggedServices('automapper.transformer_factory', $container) as $transformerFactory) {
+            $chainTransformerFactory->addMethodCall('addTransformerFactory', [$transformerFactory]);
+        }
+
+        $automapper = $container->getDefinition('automapper');
+
+        foreach ($this->findAndSortTaggedServices('automapper.mapper_metadata', $container) as $mapperMetadata) {
+            $automapper->addMethodCall('register', [$mapperMetadata]);
+        }
+        foreach ($this->findAndSortTaggedServices('automapper.mapper_configuration', $container) as $mapperConfiguration) {
+            $automapper->addMethodCall('addMapperConfiguration', [$mapperConfiguration]);
+        }
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Exception/CacheWarmupDataException.php
+++ b/src/Symfony/Component/AutoMapper/Exception/CacheWarmupDataException.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+ namespace Symfony\Component\AutoMapper\Exception;
+
+/**
+ * @internal
+ */
+final class CacheWarmupDataException extends \RuntimeException
+{
+    private function __construct(string $message, string $source, string $target)
+    {
+        parent::__construct(
+            "Invalid automapper warmup configuration: $message. {source: \"$source\", target: \"$target\"} given."
+        );
+    }
+
+    public static function sourceAndTargetAreEquals(string $value): self
+    {
+        return new self('source and target must be different', $value, $value);
+    }
+
+    public static function sourceOrTargetDoesNoExist(string $source, string $target): self
+    {
+        return new self('source and target must be "array" or a valid class name', $source, $target);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Exception/CircularReferenceException.php
+++ b/src/Symfony/Component/AutoMapper/Exception/CircularReferenceException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Exception;
+
+/**
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class CircularReferenceException extends RuntimeException
+{
+}

--- a/src/Symfony/Component/AutoMapper/Exception/CompileException.php
+++ b/src/Symfony/Component/AutoMapper/Exception/CompileException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Exception;
+
+/**
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class CompileException extends RuntimeException
+{
+}

--- a/src/Symfony/Component/AutoMapper/Exception/InvalidMappingException.php
+++ b/src/Symfony/Component/AutoMapper/Exception/InvalidMappingException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Exception;
+
+/**
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class InvalidMappingException extends RuntimeException
+{
+}

--- a/src/Symfony/Component/AutoMapper/Exception/NoMappingFoundException.php
+++ b/src/Symfony/Component/AutoMapper/Exception/NoMappingFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Exception;
+
+/**
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class NoMappingFoundException extends RuntimeException
+{
+}

--- a/src/Symfony/Component/AutoMapper/Exception/ReadOnlyTargetException.php
+++ b/src/Symfony/Component/AutoMapper/Exception/ReadOnlyTargetException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Exception;
+
+use Symfony\Component\AutoMapper\MapperContext;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class ReadOnlyTargetException extends RuntimeException
+{
+    public function __construct(int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct(sprintf('Cannot use readonly class as an object to populate. You can opt-out this behavior by using the context "%s"', MapperContext::ALLOW_READONLY_TARGET_TO_POPULATE), $code, $previous);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Exception/RuntimeException.php
+++ b/src/Symfony/Component/AutoMapper/Exception/RuntimeException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Exception;
+
+/**
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class RuntimeException extends \RuntimeException
+{
+}

--- a/src/Symfony/Component/AutoMapper/Extractor/FromSourceMappingExtractor.php
+++ b/src/Symfony/Component/AutoMapper/Extractor/FromSourceMappingExtractor.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Extractor;
+
+use Symfony\Component\AutoMapper\Exception\InvalidMappingException;
+use Symfony\Component\AutoMapper\MapperMetadataInterface;
+use Symfony\Component\AutoMapper\Transformer\TransformerFactoryInterface;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyReadInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyWriteInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
+
+/**
+ * Mapping extracted only from source, useful when not having metadata on the target for dynamic data like array, \stdClass, ...
+ *
+ * Can use a NameConverter to use specific properties name in the target
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class FromSourceMappingExtractor extends MappingExtractor
+{
+    private const ALLOWED_TARGETS = ['array', \stdClass::class];
+
+    public function __construct(
+        PropertyInfoExtractorInterface $propertyInfoExtractor,
+        PropertyReadInfoExtractorInterface $readInfoExtractor,
+        PropertyWriteInfoExtractorInterface $writeInfoExtractor,
+        TransformerFactoryInterface $transformerFactory,
+        ClassMetadataFactoryInterface $classMetadataFactory = null,
+        private readonly ?AdvancedNameConverterInterface $nameConverter = null)
+    {
+        parent::__construct($propertyInfoExtractor, $readInfoExtractor, $writeInfoExtractor, $transformerFactory, $classMetadataFactory);
+    }
+
+    public function getPropertiesMapping(MapperMetadataInterface $mapperMetadata): array
+    {
+        $sourceProperties = $this->propertyInfoExtractor->getProperties($mapperMetadata->getSource());
+
+        if (!\in_array($mapperMetadata->getTarget(), self::ALLOWED_TARGETS, true)) {
+            throw new InvalidMappingException('Only array or stdClass are accepted as a target');
+        }
+
+        if (null === $sourceProperties) {
+            return [];
+        }
+
+        $sourceProperties = array_unique($sourceProperties);
+        $mapping = [];
+
+        foreach ($sourceProperties as $property) {
+            if (!$this->propertyInfoExtractor->isReadable($mapperMetadata->getSource(), $property)) {
+                continue;
+            }
+
+            $sourceTypes = $this->propertyInfoExtractor->getTypes($mapperMetadata->getSource(), $property);
+
+            if (null === $sourceTypes) {
+                $sourceTypes = [new Type(Type::BUILTIN_TYPE_NULL)]; // if no types found, we force a null type
+            }
+
+            $targetTypes = [];
+
+            foreach ($sourceTypes as $type) {
+                $targetTypes[] = $this->transformType($mapperMetadata->getTarget(), $type);
+            }
+
+            $transformer = $this->transformerFactory->getTransformer($sourceTypes, $targetTypes, $mapperMetadata);
+
+            if (null === $transformer) {
+                continue;
+            }
+
+            $mapping[] = new PropertyMapping(
+                $this->getReadAccessor($mapperMetadata->getSource(), $mapperMetadata->getTarget(), $property),
+                $this->getWriteMutator($mapperMetadata->getSource(), $mapperMetadata->getTarget(), $property),
+                null,
+                $transformer,
+                $property,
+                false,
+                $this->getGroups($mapperMetadata->getSource(), $property),
+                $this->getGroups($mapperMetadata->getTarget(), $property),
+                $this->getMaxDepth($mapperMetadata->getSource(), $property),
+                $this->isIgnoredProperty($mapperMetadata->getSource(), $property),
+                $this->isIgnoredProperty($mapperMetadata->getTarget(), $property)
+            );
+        }
+
+        return $mapping;
+    }
+
+    private function transformType(string $target, Type $type = null): ?Type
+    {
+        if (null === $type) {
+            return null;
+        }
+
+        $builtinType = $type->getBuiltinType();
+        $className = $type->getClassName();
+
+        if (Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType() && \stdClass::class !== $type->getClassName()) {
+            $builtinType = 'array' === $target ? Type::BUILTIN_TYPE_ARRAY : Type::BUILTIN_TYPE_OBJECT;
+            $className = 'array' === $target ? null : \stdClass::class;
+        }
+
+        // Use string for datetime
+        if (Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType() && (\DateTimeInterface::class === $type->getClassName() || is_subclass_of($type->getClassName(), \DateTimeInterface::class))) {
+            $builtinType = 'string';
+        }
+
+        $collectionKeyTypes = $type->getCollectionKeyTypes();
+        $collectionValueTypes = $type->getCollectionValueTypes();
+
+        return new Type(
+            $builtinType,
+            $type->isNullable(),
+            $className,
+            $type->isCollection(),
+            $this->transformType($target, $collectionKeyTypes[0] ?? null),
+            $this->transformType($target, $collectionValueTypes[0] ?? null)
+        );
+    }
+
+    public function getWriteMutator(string $source, string $target, string $property, array $context = []): WriteMutator
+    {
+        if (null !== $this->nameConverter) {
+            $property = $this->nameConverter->normalize($property, $source, $target);
+        }
+
+        $targetMutator = new WriteMutator(WriteMutatorType::ARRAY_DIMENSION, $property, false);
+
+        if (\stdClass::class === $target) {
+            $targetMutator = new WriteMutator(WriteMutatorType::PROPERTY, $property, false);
+        }
+
+        return $targetMutator;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Extractor/FromTargetMappingExtractor.php
+++ b/src/Symfony/Component/AutoMapper/Extractor/FromTargetMappingExtractor.php
@@ -1,0 +1,180 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Extractor;
+
+use Symfony\Component\AutoMapper\Exception\InvalidMappingException;
+use Symfony\Component\AutoMapper\MapperMetadataInterface;
+use Symfony\Component\AutoMapper\Transformer\TransformerFactoryInterface;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyReadInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyWriteInfo;
+use Symfony\Component\PropertyInfo\PropertyWriteInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
+
+/**
+ * Mapping extracted only from target, useful when not having metadata on the source for dynamic data like array, \stdClass, ...
+ *
+ * Can use a NameConverter to use specific properties name in the source
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class FromTargetMappingExtractor extends MappingExtractor
+{
+    private const ALLOWED_SOURCES = ['array', \stdClass::class];
+
+    public function __construct(
+        PropertyInfoExtractorInterface $propertyInfoExtractor,
+        PropertyReadInfoExtractorInterface $readInfoExtractor,
+        PropertyWriteInfoExtractorInterface $writeInfoExtractor,
+        TransformerFactoryInterface $transformerFactory,
+        ClassMetadataFactoryInterface $classMetadataFactory = null,
+        private readonly ?AdvancedNameConverterInterface $nameConverter = null)
+    {
+        parent::__construct($propertyInfoExtractor, $readInfoExtractor, $writeInfoExtractor, $transformerFactory, $classMetadataFactory);
+    }
+
+    public function getPropertiesMapping(MapperMetadataInterface $mapperMetadata): array
+    {
+        $targetProperties = array_unique($this->propertyInfoExtractor->getProperties($mapperMetadata->getTarget()) ?? []);
+
+        if (!\in_array($mapperMetadata->getSource(), self::ALLOWED_SOURCES, true)) {
+            throw new InvalidMappingException('Only array or stdClass are accepted as a source');
+        }
+
+        $mapping = [];
+
+        foreach ($targetProperties as $property) {
+            if (!$this->isWritable($mapperMetadata->getTarget(), $property)) {
+                continue;
+            }
+
+            $targetTypes = $this->propertyInfoExtractor->getTypes($mapperMetadata->getTarget(), $property);
+
+            if (null === $targetTypes) {
+                continue;
+            }
+
+            $sourceTypes = [];
+
+            foreach ($targetTypes as $type) {
+                $sourceTypes[] = $this->transformType($mapperMetadata->getSource(), $type);
+            }
+
+            $transformer = $this->transformerFactory->getTransformer($sourceTypes, $targetTypes, $mapperMetadata);
+
+            if (null === $transformer) {
+                continue;
+            }
+
+            $mapping[] = new PropertyMapping(
+                $this->getReadAccessor($mapperMetadata->getSource(), $mapperMetadata->getTarget(), $property),
+                $this->getWriteMutator($mapperMetadata->getSource(), $mapperMetadata->getTarget(), $property, [
+                    'enable_constructor_extraction' => false,
+                ]),
+                $this->getWriteMutator($mapperMetadata->getSource(), $mapperMetadata->getTarget(), $property, [
+                    'enable_constructor_extraction' => true,
+                ]),
+                $transformer,
+                $property,
+                true,
+                $this->getGroups($mapperMetadata->getSource(), $property),
+                $this->getGroups($mapperMetadata->getTarget(), $property),
+                $this->getMaxDepth($mapperMetadata->getTarget(), $property),
+                $this->isIgnoredProperty($mapperMetadata->getSource(), $property),
+                $this->isIgnoredProperty($mapperMetadata->getTarget(), $property)
+            );
+        }
+
+        return $mapping;
+    }
+
+    public function getReadAccessor(string $source, string $target, string $property): ?ReadAccessor
+    {
+        if (null !== $this->nameConverter) {
+            $property = $this->nameConverter->normalize($property, $target, $source);
+        }
+
+        $sourceAccessor = new ReadAccessor(ReadAccessorType::ARRAY_DIMENSION, $property);
+
+        if (\stdClass::class === $source) {
+            $sourceAccessor = new ReadAccessor(ReadAccessorType::PROPERTY, $property);
+        }
+
+        return $sourceAccessor;
+    }
+
+    private function transformType(string $source, Type $type = null): ?Type
+    {
+        if (null === $type) {
+            return null;
+        }
+
+        $builtinType = $type->getBuiltinType();
+        $className = $type->getClassName();
+
+        if (Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType() && \stdClass::class !== $type->getClassName()) {
+            $builtinType = 'array' === $source ? Type::BUILTIN_TYPE_ARRAY : Type::BUILTIN_TYPE_OBJECT;
+            $className = 'array' === $source ? null : \stdClass::class;
+        }
+
+        if (Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType() && (\DateTimeInterface::class === $type->getClassName() || is_subclass_of($type->getClassName(), \DateTimeInterface::class))) {
+            $builtinType = 'string';
+        }
+
+        $collectionKeyTypes = $type->getCollectionKeyTypes();
+        $collectionValueTypes = $type->getCollectionValueTypes();
+
+        return new Type(
+            $builtinType,
+            $type->isNullable(),
+            $className,
+            $type->isCollection(),
+            $this->transformType($source, $collectionKeyTypes[0] ?? null),
+            $this->transformType($source, $collectionValueTypes[0] ?? null)
+        );
+    }
+
+    /**
+     * PropertyInfoExtractor::isWritable() is not enough: we want to know if the property is readonly and writable from the constructor.
+     */
+    private function isWritable(string $target, string $property): bool
+    {
+        if ($this->propertyInfoExtractor->isWritable($target, $property)) {
+            return true;
+        }
+
+        if (\PHP_VERSION_ID < 80100) {
+            return false;
+        }
+
+        try {
+            $reflectionProperty = new \ReflectionProperty($target, $property);
+        } catch (\ReflectionException $e) {
+            // the property does not exist
+            return false;
+        }
+
+        if (!$reflectionProperty->isReadOnly()) {
+            return false;
+        }
+
+        $writeInfo = $this->writeInfoExtractor->getWriteInfo($target, $property, ['enable_constructor_extraction' => true]);
+        if ($writeInfo->getType() !== PropertyWriteInfo::TYPE_CONSTRUCTOR) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Extractor/MappingExtractor.php
+++ b/src/Symfony/Component/AutoMapper/Extractor/MappingExtractor.php
@@ -1,0 +1,190 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Extractor;
+
+use Symfony\Component\AutoMapper\Transformer\TransformerFactoryInterface;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyReadInfo;
+use Symfony\Component\PropertyInfo\PropertyReadInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyWriteInfo;
+use Symfony\Component\PropertyInfo\PropertyWriteInfoExtractorInterface;
+use Symfony\Component\Serializer\Mapping\AttributeMetadataInterface;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+
+/**
+ * @internal
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+abstract class MappingExtractor implements MappingExtractorInterface
+{
+    public function __construct(
+        protected readonly PropertyInfoExtractorInterface $propertyInfoExtractor,
+        private readonly PropertyReadInfoExtractorInterface $readInfoExtractor,
+        protected readonly PropertyWriteInfoExtractorInterface $writeInfoExtractor,
+        protected readonly TransformerFactoryInterface $transformerFactory,
+        private readonly ?ClassMetadataFactoryInterface $classMetadataFactory = null
+    ) {
+    }
+
+    public function getReadAccessor(string $source, string $target, string $property): ?ReadAccessor
+    {
+        $readInfo = $this->readInfoExtractor->getReadInfo($source, $property);
+
+        if (null === $readInfo) {
+            return null;
+        }
+
+        $type = ReadAccessorType::PROPERTY;
+
+        if (PropertyReadInfo::TYPE_METHOD === $readInfo->getType()) {
+            $type = ReadAccessorType::METHOD;
+        }
+
+        return new ReadAccessor(
+            $type,
+            $readInfo->getName(),
+            PropertyReadInfo::VISIBILITY_PUBLIC !== $readInfo->getVisibility()
+        );
+    }
+
+    public function getWriteMutator(string $source, string $target, string $property, array $context = []): ?WriteMutator
+    {
+        $writeInfo = $this->writeInfoExtractor->getWriteInfo($target, $property, $context);
+
+        if (null === $writeInfo) {
+            return null;
+        }
+
+        if (PropertyWriteInfo::TYPE_NONE === $writeInfo->getType()) {
+            return null;
+        }
+
+        if (PropertyWriteInfo::TYPE_CONSTRUCTOR === $writeInfo->getType()) {
+            $parameter = new \ReflectionParameter([$target, '__construct'], $writeInfo->getName());
+
+            return new WriteMutator(WriteMutatorType::CONSTRUCTOR, $writeInfo->getName(), false, $parameter);
+        }
+
+        // The reported WriteInfo of readonly promoted properties is incorrectly returned as a writeable property when constructor extraction is disabled.
+        // see https://github.com/symfony/symfony/pull/48108
+        if (
+            ($context['enable_constructor_extraction'] ?? true) === false
+            && \PHP_VERSION_ID >= 80100
+            && PropertyWriteInfo::TYPE_PROPERTY === $writeInfo->getType()
+        ) {
+            $reflectionProperty = new \ReflectionProperty($target, $property);
+
+            if ($reflectionProperty->isReadOnly() || $reflectionProperty->isPromoted()) {
+                return null;
+            }
+        }
+
+        $type = WriteMutatorType::PROPERTY;
+
+        if (PropertyWriteInfo::TYPE_METHOD === $writeInfo->getType()) {
+            $type = WriteMutatorType::METHOD;
+        }
+
+        if (PropertyWriteInfo::TYPE_ADDER_AND_REMOVER === $writeInfo->getType()) {
+            $type = WriteMutatorType::ADDER_AND_REMOVER;
+            $writeInfo = $writeInfo->getAdderInfo();
+        }
+
+        return new WriteMutator(
+            $type,
+            $writeInfo->getName(),
+            PropertyReadInfo::VISIBILITY_PUBLIC !== $writeInfo->getVisibility()
+        );
+    }
+
+    protected function getMaxDepth($class, $property): ?int
+    {
+        if ('array' === $class) {
+            return null;
+        }
+
+        if (null === $this->classMetadataFactory) {
+            return null;
+        }
+
+        if (!$this->classMetadataFactory->getMetadataFor($class)) {
+            return null;
+        }
+
+        $serializerClassMetadata = $this->classMetadataFactory->getMetadataFor($class);
+        $maxDepth = null;
+
+        foreach ($serializerClassMetadata->getAttributesMetadata() as $serializerAttributeMetadata) {
+            if ($serializerAttributeMetadata->getName() === $property) {
+                $maxDepth = $serializerAttributeMetadata->getMaxDepth();
+            }
+        }
+
+        return $maxDepth;
+    }
+
+    protected function getGroups($class, $property): ?array
+    {
+        if ('array' === $class) {
+            return null;
+        }
+
+        if (null === $this->classMetadataFactory || !$this->classMetadataFactory->getMetadataFor($class)) {
+            return null;
+        }
+
+        $serializerClassMetadata = $this->classMetadataFactory->getMetadataFor($class);
+        $anyGroupFound = false;
+        $groups = [];
+
+        foreach ($serializerClassMetadata->getAttributesMetadata() as $serializerAttributeMetadata) {
+            $groupsFound = $serializerAttributeMetadata->getGroups();
+
+            if ($groupsFound) {
+                $anyGroupFound = true;
+            }
+
+            if ($serializerAttributeMetadata->getName() === $property) {
+                $groups = $groupsFound;
+            }
+        }
+
+        if (!$anyGroupFound) {
+            return null;
+        }
+
+        return $groups;
+    }
+
+    protected function isIgnoredProperty($class, $property): bool
+    {
+        if ('array' === $class || !method_exists(AttributeMetadataInterface::class, 'isIgnored')) {
+            return false;
+        }
+
+        if (null === $this->classMetadataFactory || !$this->classMetadataFactory->getMetadataFor($class)) {
+            return false;
+        }
+
+        $serializerClassMetadata = $this->classMetadataFactory->getMetadataFor($class);
+
+        foreach ($serializerClassMetadata->getAttributesMetadata() as $serializerAttributeMetadata) {
+            if ($serializerAttributeMetadata->getName() === $property) {
+                return $serializerAttributeMetadata->isIgnored();
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Extractor/MappingExtractorInterface.php
+++ b/src/Symfony/Component/AutoMapper/Extractor/MappingExtractorInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Extractor;
+
+use Symfony\Component\AutoMapper\MapperMetadataInterface;
+
+/**
+ * Extracts mapping.
+ *
+ * @internal
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+interface MappingExtractorInterface
+{
+    /**
+     * Extracts properties mapped for a given source and target.
+     *
+     * @return PropertyMapping[]
+     */
+    public function getPropertiesMapping(MapperMetadataInterface $mapperMetadata): array;
+
+    /**
+     * Extracts read accessor for a given source, target and property.
+     */
+    public function getReadAccessor(string $source, string $target, string $property): ?ReadAccessor;
+
+    /**
+     * Extracts write mutator for a given source, target and property.
+     */
+    public function getWriteMutator(string $source, string $target, string $property, array $context = []): ?WriteMutator;
+}

--- a/src/Symfony/Component/AutoMapper/Extractor/PropertyMapping.php
+++ b/src/Symfony/Component/AutoMapper/Extractor/PropertyMapping.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Extractor;
+
+use Symfony\Component\AutoMapper\Transformer\TransformerInterface;
+
+/**
+ * Property mapping.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class PropertyMapping
+{
+    public function __construct(
+        public readonly ReadAccessor $readAccessor,
+        public readonly ?WriteMutator $writeMutator,
+        public readonly ?WriteMutator $writeMutatorConstructor,
+        public readonly TransformerInterface $transformer,
+        public readonly string $property,
+        public readonly bool $checkExists = false,
+        public readonly ?array $sourceGroups = null,
+        public readonly ?array $targetGroups = null,
+        public readonly ?int $maxDepth = null,
+        public readonly bool $sourceIgnored = false,
+        public readonly bool $targetIgnored = false,
+    ) {
+    }
+
+    public function shouldIgnoreProperty(): bool
+    {
+        return $this->sourceIgnored || $this->targetIgnored;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Extractor/ReadAccessor.php
+++ b/src/Symfony/Component/AutoMapper/Extractor/ReadAccessor.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Extractor;
+
+use Symfony\Component\AutoMapper\Exception\CompileException;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+use PhpParser\Node\Param;
+use PhpParser\Node\Scalar;
+use PhpParser\Node\Stmt;
+
+/**
+ * Read accessor tell how to read from a property.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class ReadAccessor
+{
+    public function __construct(
+        private readonly ReadAccessorType $type,
+        private readonly string $name,
+        private readonly bool $private = false
+    ) {
+    }
+
+    /**
+     * Get AST expression for reading property from an input.
+     *
+     * @throws CompileException
+     */
+    public function getExpression(Expr\Variable $input): Expr
+    {
+        if (ReadAccessorType::METHOD === $this->type) {
+            return new Expr\MethodCall($input, $this->name);
+        }
+
+        if (ReadAccessorType::PROPERTY === $this->type) {
+            if ($this->private) {
+                return new Expr\FuncCall(
+                    new Expr\ArrayDimFetch(new Expr\PropertyFetch(new Expr\Variable('this'), 'extractCallbacks'), new Scalar\String_($this->name)),
+                    [
+                        new Arg($input),
+                    ]
+                );
+            }
+
+            return new Expr\PropertyFetch($input, $this->name);
+        }
+
+        if (ReadAccessorType::ARRAY_DIMENSION === $this->type) {
+            return new Expr\ArrayDimFetch($input, new Scalar\String_($this->name));
+        }
+
+        if (ReadAccessorType::SOURCE === $this->type) {
+            return $input;
+        }
+
+        throw new CompileException('Invalid accessor for read expression');
+    }
+
+    /**
+     * Get AST expression for binding closure when dealing with a private property.
+     */
+    public function getExtractCallback($className): ?Expr
+    {
+        if (ReadAccessorType::PROPERTY !== $this->type || !$this->private) {
+            return null;
+        }
+
+        return new Expr\StaticCall(new Name\FullyQualified(\Closure::class), 'bind', [
+            new Arg(new Expr\Closure([
+                'params' => [
+                    new Param(new Expr\Variable('object')),
+                ],
+                'stmts' => [
+                    new Stmt\Return_(new Expr\PropertyFetch(new Expr\Variable('object'), $this->name)),
+                ],
+            ])),
+            new Arg(new Expr\ConstFetch(new Name('null'))),
+            new Arg(new Scalar\String_(new Name\FullyQualified($className))),
+        ]);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Extractor/ReadAccessorType.php
+++ b/src/Symfony/Component/AutoMapper/Extractor/ReadAccessorType.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Extractor;
+
+/**
+ * @internal
+ *
+ * Read accessor types
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+enum ReadAccessorType
+{
+    case METHOD;
+    case PROPERTY;
+    case ARRAY_DIMENSION;
+    case SOURCE;
+}

--- a/src/Symfony/Component/AutoMapper/Extractor/SourceTargetMappingExtractor.php
+++ b/src/Symfony/Component/AutoMapper/Extractor/SourceTargetMappingExtractor.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Extractor;
+
+use Symfony\Component\AutoMapper\MapperMetadataInterface;
+
+/**
+ * Extracts mapping between two objects, only gives properties that have the same name.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class SourceTargetMappingExtractor extends MappingExtractor
+{
+    public function getPropertiesMapping(MapperMetadataInterface $mapperMetadata): array
+    {
+        $sourceProperties = $this->propertyInfoExtractor->getProperties($mapperMetadata->getSource());
+        $targetProperties = $this->propertyInfoExtractor->getProperties($mapperMetadata->getTarget());
+
+        if (null === $sourceProperties || null === $targetProperties) {
+            return [];
+        }
+
+        $sourceProperties = array_unique($sourceProperties);
+        $targetProperties = array_unique($targetProperties);
+
+        $mapping = [];
+
+        foreach ($sourceProperties as $property) {
+            if (!$this->propertyInfoExtractor->isReadable($mapperMetadata->getSource(), $property)) {
+                continue;
+            }
+
+            if (\in_array($property, $targetProperties, true)) {
+                $targetMutatorConstruct = $this->getWriteMutator($mapperMetadata->getSource(), $mapperMetadata->getTarget(), $property, [
+                    'enable_constructor_extraction' => true,
+                ]);
+
+                if ((null === $targetMutatorConstruct || null === $targetMutatorConstruct->getParameter()) && !$this->propertyInfoExtractor->isWritable($mapperMetadata->getTarget(), $property)) {
+                    continue;
+                }
+
+                $sourceTypes = $this->propertyInfoExtractor->getTypes($mapperMetadata->getSource(), $property);
+                $targetTypes = $this->propertyInfoExtractor->getTypes($mapperMetadata->getTarget(), $property);
+                $transformer = $this->transformerFactory->getTransformer($sourceTypes, $targetTypes, $mapperMetadata);
+
+                if (null === $transformer) {
+                    continue;
+                }
+
+                $sourceAccessor = $this->getReadAccessor($mapperMetadata->getSource(), $mapperMetadata->getTarget(), $property);
+                $targetMutator = $this->getWriteMutator($mapperMetadata->getSource(), $mapperMetadata->getTarget(), $property, [
+                    'enable_constructor_extraction' => false,
+                ]);
+
+                $maxDepthSource = $this->getMaxDepth($mapperMetadata->getSource(), $property);
+                $maxDepthTarget = $this->getMaxDepth($mapperMetadata->getTarget(), $property);
+                $maxDepth = null;
+
+                if (null !== $maxDepthSource && null !== $maxDepthTarget) {
+                    $maxDepth = min($maxDepthSource, $maxDepthTarget);
+                } elseif (null !== $maxDepthSource) {
+                    $maxDepth = $maxDepthSource;
+                } elseif (null !== $maxDepthTarget) {
+                    $maxDepth = $maxDepthTarget;
+                }
+
+                $mapping[] = new PropertyMapping(
+                    $sourceAccessor,
+                    $targetMutator,
+                    WriteMutatorType::CONSTRUCTOR === $targetMutatorConstruct->getType() ? $targetMutatorConstruct : null,
+                    $transformer,
+                    $property,
+                    false,
+                    $this->getGroups($mapperMetadata->getSource(), $property),
+                    $this->getGroups($mapperMetadata->getTarget(), $property),
+                    $maxDepth
+                );
+            }
+        }
+
+        return $mapping;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Extractor/WriteMutator.php
+++ b/src/Symfony/Component/AutoMapper/Extractor/WriteMutator.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Extractor;
+
+use Symfony\Component\AutoMapper\Exception\CompileException;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+use PhpParser\Node\Param;
+use PhpParser\Node\Scalar;
+use PhpParser\Node\Stmt;
+
+/**
+ * Writes mutator tell how to write to a property.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class WriteMutator
+{
+    public function __construct(
+        private readonly WriteMutatorType $type,
+        private readonly string $name,
+        private readonly bool $private = false,
+        private readonly ?\ReflectionParameter $parameter = null
+    ) {
+    }
+
+    public function getType(): WriteMutatorType
+    {
+        return $this->type;
+    }
+
+    /**
+     * Get AST expression for writing from a value to an output.
+     *
+     * @throws CompileException
+     */
+    public function getExpression(Expr\Variable $output, Expr $value, bool $byRef = false): ?Expr
+    {
+        if (WriteMutatorType::METHOD === $this->type || WriteMutatorType::ADDER_AND_REMOVER === $this->type) {
+            return new Expr\MethodCall($output, $this->name, [
+                new Arg($value),
+            ]);
+        }
+
+        if (WriteMutatorType::PROPERTY === $this->type) {
+            if ($this->private) {
+                return new Expr\FuncCall(
+                    new Expr\ArrayDimFetch(new Expr\PropertyFetch(new Expr\Variable('this'), 'hydrateCallbacks'), new Scalar\String_($this->name)),
+                    [
+                        new Arg($output),
+                        new Arg($value),
+                    ]
+                );
+            }
+            if ($byRef) {
+                return new Expr\AssignRef(new Expr\PropertyFetch($output, $this->name), $value);
+            }
+
+            return new Expr\Assign(new Expr\PropertyFetch($output, $this->name), $value);
+        }
+
+        if (WriteMutatorType::ARRAY_DIMENSION === $this->type) {
+            if ($byRef) {
+                return new Expr\AssignRef(new Expr\ArrayDimFetch($output, new Scalar\String_($this->name)), $value);
+            }
+
+            return new Expr\Assign(new Expr\ArrayDimFetch($output, new Scalar\String_($this->name)), $value);
+        }
+
+        throw new CompileException('Invalid accessor for write expression');
+    }
+
+    /**
+     * Get AST expression for binding closure when dealing with private property.
+     */
+    public function getHydrateCallback($className): ?Expr
+    {
+        if (WriteMutatorType::PROPERTY !== $this->type || !$this->private) {
+            return null;
+        }
+
+        return new Expr\StaticCall(new Name\FullyQualified(\Closure::class), 'bind', [
+            new Arg(new Expr\Closure([
+                'params' => [
+                    new Param(new Expr\Variable('object')),
+                    new Param(new Expr\Variable('value')),
+                ],
+                'stmts' => [
+                    new Stmt\Expression(new Expr\Assign(new Expr\PropertyFetch(new Expr\Variable('object'), $this->name), new Expr\Variable('value'))),
+                ],
+            ])),
+            new Arg(new Expr\ConstFetch(new Name('null'))),
+            new Arg(new Scalar\String_(new Name\FullyQualified($className))),
+        ]);
+    }
+
+    /**
+     * Get reflection parameter.
+     */
+    public function getParameter(): ?\ReflectionParameter
+    {
+        return $this->parameter;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Extractor/WriteMutatorType.php
+++ b/src/Symfony/Component/AutoMapper/Extractor/WriteMutatorType.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Extractor;
+
+/**
+ * @internal
+ *
+ * Write mutator types
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+enum WriteMutatorType
+{
+    case METHOD;
+    case PROPERTY;
+    case ARRAY_DIMENSION;
+    case CONSTRUCTOR;
+    case ADDER_AND_REMOVER;
+}

--- a/src/Symfony/Component/AutoMapper/GeneratedMapper.php
+++ b/src/Symfony/Component/AutoMapper/GeneratedMapper.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper;
+
+/**
+ * Class derived for each generated mapper.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+abstract class GeneratedMapper implements MapperInterface
+{
+    protected array $mappers = [];
+
+    /** @var array<string, callable> */
+    protected array $callbacks;
+
+    /** @var array<string, callable> */
+    protected array $hydrateCallbacks = [];
+
+    /** @var array<string, callable> */
+    protected array $extractCallbacks = [];
+
+    protected object $cachedTarget;
+
+    /** @var callable|null */
+    protected $circularReferenceHandler = null;
+
+    protected ?int $circularReferenceLimit = null;
+
+    /**
+     * Add a callable for a specific property.
+     */
+    public function addCallback(string $name, callable $callback): void
+    {
+        $this->callbacks[$name] = $callback;
+    }
+
+    /**
+     * Inject sub mappers.
+     */
+    public function injectMappers(AutoMapperRegistryInterface $autoMapperRegistry): void
+    {
+    }
+
+    public function setCircularReferenceHandler(?callable $circularReferenceHandler): void
+    {
+        $this->circularReferenceHandler = $circularReferenceHandler;
+    }
+
+    public function setCircularReferenceLimit(?int $circularReferenceLimit): void
+    {
+        $this->circularReferenceLimit = $circularReferenceLimit;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Generator/Generator.php
+++ b/src/Symfony/Component/AutoMapper/Generator/Generator.php
@@ -1,0 +1,507 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Generator;
+
+use Symfony\Component\AutoMapper\AutoMapperRegistryInterface;
+use Symfony\Component\AutoMapper\Exception\CompileException;
+use Symfony\Component\AutoMapper\Extractor\WriteMutatorType;
+use Symfony\Component\AutoMapper\GeneratedMapper;
+use Symfony\Component\AutoMapper\MapperContext;
+use Symfony\Component\AutoMapper\MapperGeneratorMetadataInterface;
+use Symfony\Component\AutoMapper\Transformer\AssignedByReferenceTransformerInterface;
+use Symfony\Component\AutoMapper\Transformer\DependentTransformerInterface;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+use PhpParser\Node\Param;
+use PhpParser\Node\Scalar;
+use PhpParser\Node\Stmt;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+use Symfony\Component\AutoMapper\Exception\ReadOnlyTargetException;
+use Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface;
+
+/**
+ * Generates code for a mapping class.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class Generator
+{
+    public function __construct(
+        private ?Parser $parser = null,
+        private readonly ?ClassDiscriminatorResolverInterface $classDiscriminator = null,
+        private readonly bool $allowReadOnlyTargetToPopulate = false,
+    ) {
+        $this->parser = $parser ?? (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+    }
+
+    /**
+     * Generate Class AST given metadata for a mapper.
+     *
+     * @throws CompileException
+     */
+    public function generate(MapperGeneratorMetadataInterface $mapperGeneratorMetadata): Stmt\Class_
+    {
+        $propertiesMapping = $mapperGeneratorMetadata->getPropertiesMapping();
+
+        $uniqueVariableScope = new UniqueVariableScope();
+        $sourceInput = new Expr\Variable($uniqueVariableScope->getUniqueName('value'));
+        $result = new Expr\Variable($uniqueVariableScope->getUniqueName('result'));
+        $hashVariable = new Expr\Variable($uniqueVariableScope->getUniqueName('sourceHash'));
+        $contextVariable = new Expr\Variable($uniqueVariableScope->getUniqueName('context'));
+        $constructStatements = [];
+        $addedDependencies = [];
+        $canHaveCircularDependency = $mapperGeneratorMetadata->canHaveCircularReference() && 'array' !== $mapperGeneratorMetadata->getSource();
+
+        $statements = [
+            new Stmt\If_(new Expr\BinaryOp\Identical(new Expr\ConstFetch(new Name('null')), $sourceInput), [
+                'stmts' => [new Stmt\Return_($sourceInput)],
+            ]),
+        ];
+
+        if ($canHaveCircularDependency) {
+            $statements[] = new Stmt\Expression(new Expr\Assign($hashVariable, new Expr\BinaryOp\Concat(new Expr\FuncCall(new Name('spl_object_hash'), [
+                new Arg($sourceInput),
+            ]),
+                new Scalar\String_($mapperGeneratorMetadata->getTarget())
+            )));
+            $statements[] = new Stmt\If_(new Expr\StaticCall(new Name\FullyQualified(MapperContext::class), new Name('shouldHandleCircularReference'), [
+                new Arg($contextVariable),
+                new Arg($hashVariable),
+                new Arg(new Expr\PropertyFetch(new Expr\Variable('this'), 'circularReferenceLimit')),
+            ]), [
+                'stmts' => [
+                    new Stmt\Return_(new Expr\StaticCall(new Name\FullyQualified(MapperContext::class), 'handleCircularReference', [
+                        new Arg($contextVariable),
+                        new Arg($hashVariable),
+                        new Arg($sourceInput),
+                        new Arg(new Expr\PropertyFetch(new Expr\Variable('this'), 'circularReferenceLimit')),
+                        new Arg(new Expr\PropertyFetch(new Expr\Variable('this'), 'circularReferenceHandler')),
+                    ])),
+                ],
+            ]);
+        }
+
+        [$createObjectStmts, $inConstructor, $constructStatementsForCreateObjects, $injectMapperStatements] = $this->getCreateObjectStatements($mapperGeneratorMetadata, $result, $contextVariable, $sourceInput, $uniqueVariableScope);
+        $constructStatements = array_merge($constructStatements, $constructStatementsForCreateObjects);
+
+        $targetToPopulate = new Expr\ArrayDimFetch($contextVariable, new Scalar\String_(MapperContext::TARGET_TO_POPULATE));
+        $statements[] = new Stmt\Expression(new Expr\Assign($result, new Expr\BinaryOp\Coalesce(
+            $targetToPopulate,
+            new Expr\ConstFetch(new Name('null'))
+        )));
+
+        if (!$this->allowReadOnlyTargetToPopulate && $mapperGeneratorMetadata->isTargetReadOnlyClass()) {
+            $statements[] = new Stmt\If_(
+                new Expr\BinaryOp\BooleanAnd(
+                    new Expr\BooleanNot(new Expr\BinaryOp\Coalesce(new Expr\ArrayDimFetch($contextVariable, new Scalar\String_(MapperContext::ALLOW_READONLY_TARGET_TO_POPULATE)), new Expr\ConstFetch(new Name('false')))),
+                    new Expr\FuncCall(new Name('is_object'), [new Arg(new Expr\BinaryOp\Coalesce($targetToPopulate, new Expr\ConstFetch(new Name('null'))))])
+                ), [
+                'stmts' => [new Stmt\Expression(new Expr\Throw_(new Expr\New_(new Name(ReadOnlyTargetException::class))))],
+            ]);
+        }
+
+        $statements[] = new Stmt\If_(new Expr\BinaryOp\Identical(new Expr\ConstFetch(new Name('null')), $result), [
+            'stmts' => $createObjectStmts,
+        ]);
+
+        foreach ($propertiesMapping as $propertyMapping) {
+            if (!$propertyMapping->transformer instanceof DependentTransformerInterface) {
+                continue;
+            }
+
+            foreach ($propertyMapping->transformer->getDependencies() as $dependency) {
+                if (isset($addedDependencies[$dependency->name])) {
+                    continue;
+                }
+
+                $injectMapperStatements[] = new Stmt\Expression(new Expr\Assign(
+                    new Expr\ArrayDimFetch(new Expr\PropertyFetch(new Expr\Variable('this'), 'mappers'), new Scalar\String_($dependency->name)),
+                    new Expr\MethodCall(new Expr\Variable('autoMapperRegistry'), 'getMapper', [
+                        new Arg(new Scalar\String_($dependency->source)),
+                        new Arg(new Scalar\String_($dependency->target)),
+                    ])
+                ));
+                $addedDependencies[$dependency->name] = true;
+            }
+        }
+
+        $addedDependenciesStatements = [];
+        if ($addedDependencies) {
+            if ($canHaveCircularDependency) {
+                $addedDependenciesStatements[] = new Stmt\Expression(new Expr\Assign(
+                    $contextVariable,
+                    new Expr\StaticCall(new Name\FullyQualified(MapperContext::class), 'withReference', [
+                        new Arg($contextVariable),
+                        new Arg($hashVariable),
+                        new Arg($result),
+                    ])
+                ));
+            }
+
+            $addedDependenciesStatements[] = new Stmt\Expression(new Expr\Assign(
+                $contextVariable,
+                new Expr\StaticCall(new Name\FullyQualified(MapperContext::class), 'withIncrementedDepth', [
+                    new Arg($contextVariable),
+                ])
+            ));
+        }
+
+        $duplicatedStatements = [];
+        $setterStatements = [];
+        foreach ($propertiesMapping as $propertyMapping) {
+            if ($propertyMapping->shouldIgnoreProperty()) {
+                continue;
+            }
+
+            $transformer = $propertyMapping->transformer;
+
+            $sourcePropertyAccessor = $propertyMapping->readAccessor->getExpression($sourceInput);
+            [$output, $propStatements] = $transformer->transform($sourcePropertyAccessor, $result, $propertyMapping, $uniqueVariableScope);
+
+            $extractCallback = $propertyMapping->readAccessor->getExtractCallback($mapperGeneratorMetadata->getSource());
+
+            if (null !== $extractCallback) {
+                $constructStatements[] = new Stmt\Expression(new Expr\Assign(
+                    new Expr\ArrayDimFetch(new Expr\PropertyFetch(new Expr\Variable('this'), 'extractCallbacks'), new Scalar\String_($propertyMapping->property)),
+                    $extractCallback
+                ));
+            }
+
+            if (null === $propertyMapping->writeMutator) {
+                continue;
+            }
+
+            if (WriteMutatorType::ADDER_AND_REMOVER !== $propertyMapping->writeMutator->getType()) {
+                $writeExpression = $propertyMapping->writeMutator->getExpression($result, $output, $transformer instanceof AssignedByReferenceTransformerInterface ? $transformer->assignByRef() : false);
+                if (null === $writeExpression) {
+                    continue;
+                }
+
+                $propStatements[] = new Stmt\Expression($writeExpression);
+            }
+
+            $hydrateCallback = $propertyMapping->writeMutator->getHydrateCallback($mapperGeneratorMetadata->getTarget());
+
+            if (null !== $hydrateCallback) {
+                $constructStatements[] = new Stmt\Expression(new Expr\Assign(
+                    new Expr\ArrayDimFetch(new Expr\PropertyFetch(new Expr\Variable('this'), 'hydrateCallbacks'), new Scalar\String_($propertyMapping->property)),
+                    $hydrateCallback
+                ));
+            }
+
+            $conditions = [];
+            if ($propertyMapping->checkExists) {
+                if (\stdClass::class === $mapperGeneratorMetadata->getSource()) {
+                    $conditions[] = new Expr\FuncCall(new Name('property_exists'), [
+                        new Arg($sourceInput),
+                        new Arg(new Scalar\String_($propertyMapping->property)),
+                    ]);
+                }
+
+                if ('array' === $mapperGeneratorMetadata->getSource()) {
+                    $conditions[] = new Expr\FuncCall(new Name('array_key_exists'), [
+                        new Arg(new Scalar\String_($propertyMapping->property)),
+                        new Arg($sourceInput),
+                    ]);
+                }
+            }
+
+            if ($mapperGeneratorMetadata->shouldCheckAttributes()) {
+                $conditions[] = new Expr\StaticCall(new Name\FullyQualified(MapperContext::class), 'isAllowedAttribute', [
+                    new Arg($contextVariable),
+                    new Arg(new Scalar\String_($propertyMapping->property)),
+                    new Arg($sourcePropertyAccessor),
+                ]);
+            }
+
+            if (null !== $propertyMapping->sourceGroups) {
+                $conditions[] = new Expr\BinaryOp\BooleanAnd(
+                    new Expr\BinaryOp\NotIdentical(
+                        new Expr\ConstFetch(new Name('null')),
+                        new Expr\BinaryOp\Coalesce(
+                            new Expr\ArrayDimFetch($contextVariable, new Scalar\String_(MapperContext::GROUPS)),
+                            new Expr\Array_()
+                        )
+                    ),
+                    new Expr\FuncCall(new Name('array_intersect'), [
+                        new Arg(new Expr\BinaryOp\Coalesce(
+                            new Expr\ArrayDimFetch($contextVariable, new Scalar\String_(MapperContext::GROUPS)),
+                            new Expr\Array_()
+                        )),
+                        new Arg(new Expr\Array_(array_map(function (string $group) {
+                            return new Expr\ArrayItem(new Scalar\String_($group));
+                        }, $propertyMapping->sourceGroups))),
+                    ])
+                );
+            }
+
+            if (null !== $propertyMapping->targetGroups) {
+                $conditions[] = new Expr\BinaryOp\BooleanAnd(
+                    new Expr\BinaryOp\NotIdentical(
+                        new Expr\ConstFetch(new Name('null')),
+                        new Expr\BinaryOp\Coalesce(
+                            new Expr\ArrayDimFetch($contextVariable, new Scalar\String_(MapperContext::GROUPS)),
+                            new Expr\Array_()
+                        )
+                    ),
+                    new Expr\FuncCall(new Name('array_intersect'), [
+                        new Arg(new Expr\BinaryOp\Coalesce(
+                            new Expr\ArrayDimFetch($contextVariable, new Scalar\String_(MapperContext::GROUPS)),
+                            new Expr\Array_()
+                        )),
+                        new Arg(new Expr\Array_(array_map(function (string $group) {
+                            return new Expr\ArrayItem(new Scalar\String_($group));
+                        }, $propertyMapping->targetGroups))),
+                    ])
+                );
+            }
+
+            if (null !== $propertyMapping->maxDepth) {
+                $conditions[] = new Expr\BinaryOp\SmallerOrEqual(
+                    new Expr\BinaryOp\Coalesce(
+                        new Expr\ArrayDimFetch($contextVariable, new Scalar\String_(MapperContext::DEPTH)),
+                        new Expr\ConstFetch(new Name('0'))
+                    ),
+                    new Scalar\LNumber($propertyMapping->maxDepth)
+                );
+            }
+
+            if ($conditions) {
+                $condition = array_shift($conditions);
+
+                while ($conditions) {
+                    $condition = new Expr\BinaryOp\BooleanAnd($condition, array_shift($conditions));
+                }
+
+                $propStatements = [new Stmt\If_($condition, [
+                    'stmts' => $propStatements,
+                ])];
+            }
+
+            $propInConstructor = \in_array($propertyMapping->property, $inConstructor, true);
+            foreach ($propStatements as $propStatement) {
+                if ($propInConstructor) {
+                    $duplicatedStatements[] = $propStatement;
+                } else {
+                    $setterStatements[] = $propStatement;
+                }
+            }
+        }
+
+        if (\count($duplicatedStatements) > 0 && \count($inConstructor)) {
+            $statements[] = new Stmt\Else_(array_merge($addedDependenciesStatements, $duplicatedStatements));
+        } else {
+            foreach ($addedDependenciesStatements as $statement) {
+                $statements[] = $statement;
+            }
+        }
+
+        foreach ($setterStatements as $propStatement) {
+            $statements[] = $propStatement;
+        }
+
+        $statements[] = new Stmt\Return_($result);
+
+        $mapMethod = new Stmt\ClassMethod('map', [
+            'flags' => Stmt\Class_::MODIFIER_PUBLIC,
+            'params' => [
+                new Param(new Expr\Variable($sourceInput->name), type: 'mixed'),
+                new Param(new Expr\Variable('context'), new Expr\Array_(), 'array'),
+            ],
+            'byRef' => true,
+            'stmts' => $statements,
+            'returnType' => 'mixed',
+        ]);
+
+        $constructMethod = new Stmt\ClassMethod('__construct', [
+            'flags' => Stmt\Class_::MODIFIER_PUBLIC,
+            'stmts' => $constructStatements,
+        ]);
+
+        $classStmts = [$constructMethod, $mapMethod];
+
+        if (\count($injectMapperStatements) > 0) {
+            $classStmts[] = new Stmt\ClassMethod('injectMappers', [
+                'flags' => Stmt\Class_::MODIFIER_PUBLIC,
+                'params' => [
+                    new Param(new Expr\Variable('autoMapperRegistry'), null, new Name\FullyQualified(AutoMapperRegistryInterface::class)),
+                ],
+                'returnType' => 'void',
+                'stmts' => $injectMapperStatements,
+            ]);
+        }
+
+        return new Stmt\Class_(new Name($mapperGeneratorMetadata->getMapperClassName()), [
+            'flags' => Stmt\Class_::MODIFIER_FINAL,
+            'extends' => new Name\FullyQualified(GeneratedMapper::class),
+            'stmts' => $classStmts,
+        ]);
+    }
+
+    /**
+     * @return array{0: Stmt[], 1: string[], 2: Stmt[], 3: Stmt[]}
+     */
+    private function getCreateObjectStatements(MapperGeneratorMetadataInterface $mapperMetadata, Expr\Variable $result, Expr\Variable $contextVariable, Expr\Variable $sourceInput, UniqueVariableScope $uniqueVariableScope): array
+    {
+        $target = $mapperMetadata->getTarget();
+        $source = $mapperMetadata->getSource();
+
+        if ('array' === $target) {
+            return [[new Stmt\Expression(new Expr\Assign($result, new Expr\Array_()))], [], [], []];
+        }
+
+        if (\stdClass::class === $target && \stdClass::class === $source) {
+            return [[new Stmt\Expression(new Expr\Assign($result, new Expr\FuncCall(new Name('unserialize'), [new Arg(new Expr\FuncCall(new Name('serialize'), [new Arg($sourceInput)]))])))], [], [], []];
+        } elseif (\stdClass::class === $target) {
+            return [[new Stmt\Expression(new Expr\Assign($result, new Expr\New_(new Name(\stdClass::class))))], [], [], []];
+        }
+
+        $reflectionClass = new \ReflectionClass($target);
+        $targetConstructor = $reflectionClass->getConstructor();
+        $createObjectStatements = [];
+        $inConstructor = [];
+        $constructStatements = [];
+        $injectMapperStatements = [];
+        $classDiscriminatorMapping = $this->classDiscriminator?->getMappingForClass($target);
+
+        if (null !== $classDiscriminatorMapping && null !== ($propertyMapping = $mapperMetadata->getPropertyMapping($classDiscriminatorMapping->getTypeProperty()))) {
+            [$output, $createObjectStatements] = $propertyMapping->transformer->transform($propertyMapping->readAccessor->getExpression($sourceInput), $result, $propertyMapping, $uniqueVariableScope);
+
+            foreach ($classDiscriminatorMapping->getTypesMapping() as $typeValue => $typeTarget) {
+                $mapperName = 'Discriminator_Mapper_'.$source.'_'.$typeTarget;
+
+                $injectMapperStatements[] = new Stmt\Expression(new Expr\Assign(
+                    new Expr\ArrayDimFetch(new Expr\PropertyFetch(new Expr\Variable('this'), 'mappers'), new Scalar\String_($mapperName)),
+                    new Expr\MethodCall(new Expr\Variable('autoMapperRegistry'), 'getMapper', [
+                        new Arg(new Scalar\String_($source)),
+                        new Arg(new Scalar\String_($typeTarget)),
+                    ])
+                ));
+                $createObjectStatements[] = new Stmt\If_(new Expr\BinaryOp\Identical(
+                    new Scalar\String_($typeValue),
+                    $output
+                ), [
+                    'stmts' => [
+                        new Stmt\Return_(new Expr\MethodCall(new Expr\ArrayDimFetch(
+                            new Expr\PropertyFetch(new Expr\Variable('this'), 'mappers'),
+                            new Scalar\String_($mapperName)
+                        ), 'map', [
+                            new Arg($sourceInput),
+                            new Expr\Variable('context'),
+                        ])),
+                    ],
+                ]);
+            }
+        }
+
+        $propertiesMapping = $mapperMetadata->getPropertiesMapping();
+
+        if (null !== $targetConstructor && $mapperMetadata->hasConstructor()) {
+            $constructArguments = [];
+
+            foreach ($propertiesMapping as $propertyMapping) {
+                if (null === $propertyMapping->writeMutatorConstructor || null === ($parameter = $propertyMapping->writeMutatorConstructor->getParameter())) {
+                    continue;
+                }
+
+                $constructVar = new Expr\Variable($uniqueVariableScope->getUniqueName('constructArg'));
+
+                [$output, $propStatements] = $propertyMapping->transformer->transform($propertyMapping->readAccessor->getExpression($sourceInput), $constructVar, $propertyMapping, $uniqueVariableScope);
+                $constructArguments[$parameter->getPosition()] = new Arg($constructVar);
+
+                $propStatements[] = new Stmt\Expression(new Expr\Assign($constructVar, $output));
+                $createObjectStatements[] = new Stmt\If_(new Expr\StaticCall(new Name\FullyQualified(MapperContext::class), 'hasConstructorArgument', [
+                    new Arg($contextVariable),
+                    new Arg(new Scalar\String_($target)),
+                    new Arg(new Scalar\String_($propertyMapping->property)),
+                ]), [
+                    'stmts' => [
+                        new Stmt\Expression(new Expr\Assign($constructVar, new Expr\StaticCall(new Name\FullyQualified(MapperContext::class), 'getConstructorArgument', [
+                            new Arg($contextVariable),
+                            new Arg(new Scalar\String_($target)),
+                            new Arg(new Scalar\String_($propertyMapping->property)),
+                        ]))),
+                    ],
+                    'else' => new Stmt\Else_($propStatements),
+                ]);
+
+                $inConstructor[] = $propertyMapping->property;
+            }
+
+            foreach ($targetConstructor->getParameters() as $constructorParameter) {
+                if (!\array_key_exists($constructorParameter->getPosition(), $constructArguments) && $constructorParameter->isDefaultValueAvailable()) {
+                    $constructVar = new Expr\Variable($uniqueVariableScope->getUniqueName('constructArg'));
+
+                    $createObjectStatements[] = new Stmt\If_(new Expr\StaticCall(new Name\FullyQualified(MapperContext::class), 'hasConstructorArgument', [
+                        new Arg($contextVariable),
+                        new Arg(new Scalar\String_($target)),
+                        new Arg(new Scalar\String_($constructorParameter->getName())),
+                    ]), [
+                        'stmts' => [
+                            new Stmt\Expression(new Expr\Assign($constructVar, new Expr\StaticCall(new Name\FullyQualified(MapperContext::class), 'getConstructorArgument', [
+                                new Arg($contextVariable),
+                                new Arg(new Scalar\String_($target)),
+                                new Arg(new Scalar\String_($constructorParameter->getName())),
+                            ]))),
+                        ],
+                        'else' => new Stmt\Else_([
+                            new Stmt\Expression(new Expr\Assign($constructVar, $this->getValueAsExpr($constructorParameter->getDefaultValue()))),
+                        ]),
+                    ]);
+
+                    $constructArguments[$constructorParameter->getPosition()] = new Arg($constructVar);
+                }
+            }
+
+            ksort($constructArguments);
+
+            $createObjectStatements[] = new Stmt\Expression(new Expr\Assign($result, new Expr\New_(new Name\FullyQualified($target), $constructArguments)));
+        } elseif (null !== $targetConstructor && $mapperMetadata->isTargetCloneable()) {
+            $constructStatements[] = new Stmt\Expression(new Expr\Assign(
+                new Expr\PropertyFetch(new Expr\Variable('this'), 'cachedTarget'),
+                new Expr\MethodCall(new Expr\New_(new Name\FullyQualified(\ReflectionClass::class), [
+                    new Arg(new Scalar\String_($target)),
+                ]), 'newInstanceWithoutConstructor')
+            ));
+            $createObjectStatements[] = new Stmt\Expression(new Expr\Assign($result, new Expr\Clone_(new Expr\PropertyFetch(new Expr\Variable('this'), 'cachedTarget'))));
+        } elseif (null !== $targetConstructor) {
+            $constructStatements[] = new Stmt\Expression(new Expr\Assign(
+                new Expr\PropertyFetch(new Expr\Variable('this'), 'cachedTarget'),
+                new Expr\New_(new Name\FullyQualified(\ReflectionClass::class), [
+                    new Arg(new Scalar\String_($target)),
+                ])
+            ));
+            $createObjectStatements[] = new Stmt\Expression(new Expr\Assign($result, new Expr\MethodCall(
+                new Expr\PropertyFetch(new Expr\Variable('this'), 'cachedTarget'),
+                'newInstanceWithoutConstructor'
+            )));
+        } else {
+            $createObjectStatements[] = new Stmt\Expression(new Expr\Assign($result, new Expr\New_(new Name\FullyQualified($target))));
+        }
+
+        return [$createObjectStatements, $inConstructor, $constructStatements, $injectMapperStatements];
+    }
+
+    private function getValueAsExpr(mixed $value): Expr
+    {
+        $expr = $this->parser->parse('<?php '.var_export($value, true).';')[0];
+
+        if ($expr instanceof Stmt\Expression) {
+            return $expr->expr;
+        }
+
+        return $expr;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Generator/UniqueVariableScope.php
+++ b/src/Symfony/Component/AutoMapper/Generator/UniqueVariableScope.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Generator;
+
+/**
+ * Allows to get a unique variable name for a scope (like a method).
+ *
+ * @internal
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class UniqueVariableScope
+{
+    private array $registry = [];
+
+    /**
+     * Return a unique name for a variable name.
+     */
+    public function getUniqueName(string $name): string
+    {
+        $name = strtolower($name);
+
+        if (!isset($this->registry[$name])) {
+            $this->registry[$name] = 0;
+
+            return $name;
+        }
+
+        ++$this->registry[$name];
+
+        return sprintf('%s_%s', $name, $this->registry[$name]);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/LICENSE
+++ b/src/Symfony/Component/AutoMapper/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2023-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/AutoMapper/Loader/ClassLoaderInterface.php
+++ b/src/Symfony/Component/AutoMapper/Loader/ClassLoaderInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Loader;
+
+use Symfony\Component\AutoMapper\MapperGeneratorMetadataInterface;
+
+/**
+ * Loads (require) a mapping given metadata.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+interface ClassLoaderInterface
+{
+    public function loadClass(MapperGeneratorMetadataInterface $mapperMetadata): void;
+}

--- a/src/Symfony/Component/AutoMapper/Loader/EvalLoader.php
+++ b/src/Symfony/Component/AutoMapper/Loader/EvalLoader.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Loader;
+
+use Symfony\Component\AutoMapper\Generator\Generator;
+use Symfony\Component\AutoMapper\MapperGeneratorMetadataInterface;
+use PhpParser\PrettyPrinter\Standard;
+
+/**
+ * Use eval to load mappers.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class EvalLoader implements ClassLoaderInterface
+{
+    private Standard $printer;
+
+    public function __construct(
+        private readonly Generator $generator,
+    ) {
+        $this->printer = new Standard();
+    }
+
+    public function loadClass(MapperGeneratorMetadataInterface $mapperMetadata): void
+    {
+        $class = $this->generator->generate($mapperMetadata);
+
+        eval($this->printer->prettyPrint([$class]));
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Loader/FileLoader.php
+++ b/src/Symfony/Component/AutoMapper/Loader/FileLoader.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Loader;
+
+use Symfony\Component\AutoMapper\Generator\Generator;
+use Symfony\Component\AutoMapper\MapperGeneratorMetadataInterface;
+use PhpParser\PrettyPrinter\Standard;
+
+/**
+ * Use file system to load mapper, and persist them using a registry.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class FileLoader implements ClassLoaderInterface
+{
+    private Standard $printer;
+    private ?array $registry = null;
+
+    public function __construct(
+        private readonly Generator $generator,
+        private readonly string $directory,
+        private readonly bool $hotReload = true
+    ) {
+        $this->printer = new Standard();
+    }
+
+    public function loadClass(MapperGeneratorMetadataInterface $mapperMetadata): void
+    {
+        $className = $mapperMetadata->getMapperClassName();
+        $classPath = $this->directory.\DIRECTORY_SEPARATOR.$className.'.php';
+
+        if (!$this->hotReload && file_exists($classPath)) {
+            require $classPath;
+
+            return;
+        }
+
+        $shouldSaveMapper = true;
+        if ($this->hotReload) {
+            $registry = $this->getRegistry();
+            $hash = $mapperMetadata->getHash();
+            $shouldSaveMapper = !isset($registry[$className]) || $registry[$className] !== $hash || !file_exists($classPath);
+        }
+
+        if ($shouldSaveMapper) {
+            $this->saveMapper($mapperMetadata);
+        }
+
+        require $classPath;
+    }
+
+    /**
+     * @return string The generated class name
+     */
+    public function saveMapper(MapperGeneratorMetadataInterface $mapperGeneratorMetadata): string
+    {
+        $className = $mapperGeneratorMetadata->getMapperClassName();
+        $classPath = $this->directory.\DIRECTORY_SEPARATOR.$className.'.php';
+        $classCode = $this->printer->prettyPrint([$this->generator->generate($mapperGeneratorMetadata)]);
+
+        $this->write($classPath, "<?php\n\n".$classCode."\n");
+        if ($this->hotReload) {
+            $this->addHashToRegistry($className, $mapperGeneratorMetadata->getHash());
+        }
+
+        return $className;
+    }
+
+    private function addHashToRegistry($className, $hash): void
+    {
+        $registryPath = $this->directory.\DIRECTORY_SEPARATOR.'registry.php';
+        $this->registry[$className] = $hash;
+        $this->write($registryPath, "<?php\n\nreturn ".var_export($this->registry, true).";\n");
+    }
+
+    private function getRegistry(): array
+    {
+        if (!$this->registry) {
+            $registryPath = $this->directory.\DIRECTORY_SEPARATOR.'registry.php';
+
+            if (!file_exists($registryPath)) {
+                $this->registry = [];
+            } else {
+                $this->registry = require $registryPath;
+            }
+        }
+
+        return $this->registry;
+    }
+
+    private function write(string $file, string $contents): void
+    {
+        if (!file_exists($this->directory)) {
+            mkdir($this->directory);
+        }
+
+        $fp = fopen($file, 'w');
+
+        if (flock($fp, \LOCK_EX)) {
+            fwrite($fp, $contents);
+        }
+
+        fclose($fp);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/MapperConfigurationInterface.php
+++ b/src/Symfony/Component/AutoMapper/MapperConfigurationInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper;
+
+interface MapperConfigurationInterface
+{
+    public function process(MapperGeneratorMetadataInterface $metadata): void;
+
+    public function getSource(): string;
+
+    public function getTarget(): string;
+}

--- a/src/Symfony/Component/AutoMapper/MapperContext.php
+++ b/src/Symfony/Component/AutoMapper/MapperContext.php
@@ -1,0 +1,251 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper;
+
+use Symfony\Component\AutoMapper\Exception\CircularReferenceException;
+
+/**
+ * Context for mapping.
+ *
+ * Allows to customize how is done the mapping
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class MapperContext
+{
+    public const GROUPS = 'groups';
+    public const ALLOWED_ATTRIBUTES = 'allowed_attributes';
+    public const IGNORED_ATTRIBUTES = 'ignored_attributes';
+    public const CIRCULAR_REFERENCE_LIMIT = 'circular_reference_limit';
+    public const CIRCULAR_REFERENCE_HANDLER = 'circular_reference_handler';
+    public const CIRCULAR_REFERENCE_REGISTRY = 'circular_reference_registry';
+    public const CIRCULAR_COUNT_REFERENCE_REGISTRY = 'circular_count_reference_registry';
+    public const DEPTH = 'depth';
+    public const TARGET_TO_POPULATE = 'target_to_populate';
+    public const CONSTRUCTOR_ARGUMENTS = 'constructor_arguments';
+    public const SKIP_NULL_VALUES = 'skip_null_values';
+    public const ALLOW_READONLY_TARGET_TO_POPULATE = 'allow_readonly_target_to_populate';
+
+    private array $context = [
+        self::DEPTH => 0,
+        self::CIRCULAR_REFERENCE_REGISTRY => [],
+        self::CIRCULAR_COUNT_REFERENCE_REGISTRY => [],
+        self::CONSTRUCTOR_ARGUMENTS => [],
+    ];
+
+    public function toArray(): array
+    {
+        return $this->context;
+    }
+
+    public function setGroups(?array $groups): self
+    {
+        $this->context[self::GROUPS] = $groups;
+
+        return $this;
+    }
+
+    public function setAllowedAttributes(?array $allowedAttributes): self
+    {
+        $this->context[self::ALLOWED_ATTRIBUTES] = $allowedAttributes;
+
+        return $this;
+    }
+
+    public function setIgnoredAttributes(?array $ignoredAttributes): self
+    {
+        $this->context[self::IGNORED_ATTRIBUTES] = $ignoredAttributes;
+
+        return $this;
+    }
+
+    public function setCircularReferenceLimit(?int $circularReferenceLimit): self
+    {
+        $this->context[self::CIRCULAR_REFERENCE_LIMIT] = $circularReferenceLimit;
+
+        return $this;
+    }
+
+    public function setCircularReferenceHandler(?callable $circularReferenceHandler): self
+    {
+        $this->context[self::CIRCULAR_REFERENCE_HANDLER] = $circularReferenceHandler;
+
+        return $this;
+    }
+
+    public function setTargetToPopulate($target): self
+    {
+        $this->context[self::TARGET_TO_POPULATE] = $target;
+
+        return $this;
+    }
+
+    public function setConstructorArgument(string $class, string $key, $value): self
+    {
+        $this->context[self::CONSTRUCTOR_ARGUMENTS][$class][$key] = $value;
+
+        return $this;
+    }
+
+    public function setSkipNullValues(bool $skipNullValues): self
+    {
+        $this->context[self::SKIP_NULL_VALUES] = $skipNullValues;
+
+        return $this;
+    }
+
+    public function setAllowReadOnlyTargetToPopulate(bool $allowReadOnlyTargetToPopulate): self
+    {
+        $this->context[self::ALLOW_READONLY_TARGET_TO_POPULATE] = $allowReadOnlyTargetToPopulate;
+
+        return $this;
+    }
+
+    /**
+     * Whether a reference has reached its limit.
+     */
+    public static function shouldHandleCircularReference(array $context, string $reference, int $circularReferenceLimit = null): bool
+    {
+        if (!\array_key_exists($reference, $context[self::CIRCULAR_REFERENCE_REGISTRY] ?? [])) {
+            return false;
+        }
+
+        if (null === $circularReferenceLimit) {
+            $circularReferenceLimit = $context[self::CIRCULAR_REFERENCE_LIMIT] ?? null;
+        }
+
+        if (null !== $circularReferenceLimit) {
+            return $circularReferenceLimit <= ($context[self::CIRCULAR_COUNT_REFERENCE_REGISTRY][$reference] ?? 0);
+        }
+
+        return true;
+    }
+
+    /**
+     * Handle circular reference for a specific reference.
+     *
+     * By default, will try to keep it and return the previous value
+     */
+    public static function &handleCircularReference(array &$context, string $reference, $object, int $circularReferenceLimit = null, callable $callback = null): mixed
+    {
+        if (null === $callback) {
+            $callback = $context[self::CIRCULAR_REFERENCE_HANDLER] ?? null;
+        }
+
+        if (null !== $callback) {
+            // Cannot directly return here, as we need to return by reference, and callback may not be declared as reference return
+            $value = $callback($object, $context);
+
+            return $value;
+        }
+
+        if (null === $circularReferenceLimit) {
+            $circularReferenceLimit = $context[self::CIRCULAR_REFERENCE_LIMIT] ?? null;
+        }
+
+        if (null !== $circularReferenceLimit) {
+            if ($circularReferenceLimit <= ($context[self::CIRCULAR_COUNT_REFERENCE_REGISTRY][$reference] ?? 0)) {
+                throw new CircularReferenceException(sprintf('A circular reference has been detected when mapping the object of type "%s" (configured limit: %d)', \is_object($object) ? $object::class : 'array', $circularReferenceLimit));
+            }
+
+            ++$context[self::CIRCULAR_COUNT_REFERENCE_REGISTRY][$reference];
+        }
+
+        // When no limit defined return the object referenced
+        return $context[self::CIRCULAR_REFERENCE_REGISTRY][$reference];
+    }
+
+    /**
+     * Create a new context with a new reference.
+     */
+    public static function withReference(array $context, string $reference, &$object): array
+    {
+        $context[self::CIRCULAR_REFERENCE_REGISTRY][$reference] = &$object;
+        $context[self::CIRCULAR_COUNT_REFERENCE_REGISTRY][$reference] = $context[self::CIRCULAR_COUNT_REFERENCE_REGISTRY][$reference] ?? 0;
+        ++$context[self::CIRCULAR_COUNT_REFERENCE_REGISTRY][$reference];
+
+        return $context;
+    }
+
+    /**
+     * Check whether an attribute is allowed to be mapped.
+     */
+    public static function isAllowedAttribute(array $context, string $attribute, $value): bool
+    {
+        if (($context[self::SKIP_NULL_VALUES] ?? false) && null === $value) {
+            return false;
+        }
+
+        if (($context[self::IGNORED_ATTRIBUTES] ?? false) && \in_array($attribute, $context[self::IGNORED_ATTRIBUTES], true)) {
+            return false;
+        }
+
+        if (!($context[self::ALLOWED_ATTRIBUTES] ?? false)) {
+            return true;
+        }
+
+        return
+            \in_array($attribute, $context[self::ALLOWED_ATTRIBUTES], true) // current field is allowed
+            || isset($context[self::ALLOWED_ATTRIBUTES][$attribute]) // some nested fields are allowed
+        ;
+    }
+
+    /**
+     * Clone context with an incremented depth.
+     */
+    public static function withIncrementedDepth(array $context): array
+    {
+        $context[self::DEPTH] = $context[self::DEPTH] ?? 0;
+        ++$context[self::DEPTH];
+
+        return $context;
+    }
+
+    /**
+     * Check whether an argument exist for the constructor for a specific class.
+     */
+    public static function hasConstructorArgument(array $context, string $class, string $key): bool
+    {
+        return \array_key_exists($key, $context[self::CONSTRUCTOR_ARGUMENTS][$class] ?? []);
+    }
+
+    /**
+     * Get constructor argument for a specific class.
+     */
+    public static function getConstructorArgument(array $context, string $class, string $key): mixed
+    {
+        return $context[self::CONSTRUCTOR_ARGUMENTS][$class][$key] ?? null;
+    }
+
+    /**
+     * Create a new context, and reload attribute mapping for it.
+     */
+    public static function withNewContext(array $context, string $attribute): array
+    {
+        $context[self::TARGET_TO_POPULATE] = null;
+
+        if (!($context[self::ALLOWED_ATTRIBUTES] ?? false) && !($context[self::IGNORED_ATTRIBUTES] ?? false)) {
+            return $context;
+        }
+
+        if (\is_array($context[self::IGNORED_ATTRIBUTES][$attribute] ?? false)) {
+            $context[self::IGNORED_ATTRIBUTES] = $context[self::IGNORED_ATTRIBUTES][$attribute];
+        }
+
+        if (\is_array($context[self::ALLOWED_ATTRIBUTES][$attribute] ?? false)) {
+            $context[self::ALLOWED_ATTRIBUTES] = $context[self::ALLOWED_ATTRIBUTES][$attribute];
+        }
+
+        return $context;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/MapperGeneratorMetadataFactory.php
+++ b/src/Symfony/Component/AutoMapper/MapperGeneratorMetadataFactory.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper;
+
+use Symfony\Component\AutoMapper\Extractor\FromSourceMappingExtractor;
+use Symfony\Component\AutoMapper\Extractor\FromTargetMappingExtractor;
+use Symfony\Component\AutoMapper\Extractor\SourceTargetMappingExtractor;
+
+/**
+ * Metadata factory, used to auto-registering new mapping without creating them.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class MapperGeneratorMetadataFactory implements MapperGeneratorMetadataFactoryInterface
+{
+    public function __construct(
+        private readonly SourceTargetMappingExtractor $sourceTargetPropertiesMappingExtractor,
+        private readonly FromSourceMappingExtractor $fromSourcePropertiesMappingExtractor,
+        private readonly FromTargetMappingExtractor $fromTargetPropertiesMappingExtractor,
+        private readonly string $classPrefix = 'Mapper_',
+        private readonly bool $attributeChecking = true,
+        private readonly string $dateTimeFormat = \DateTimeInterface::RFC3339
+    ) {
+    }
+
+    /**
+     * Create metadata for a source and target.
+     */
+    public function create(MapperGeneratorMetadataRegistryInterface $autoMapperRegister, string $source, string $target): MapperGeneratorMetadataInterface
+    {
+        $extractor = $this->sourceTargetPropertiesMappingExtractor;
+
+        if ('array' === $source || 'stdClass' === $source) {
+            $extractor = $this->fromTargetPropertiesMappingExtractor;
+        }
+
+        if ('array' === $target || 'stdClass' === $target) {
+            $extractor = $this->fromSourcePropertiesMappingExtractor;
+        }
+
+        $mapperMetadata = new MapperMetadata($autoMapperRegister, $extractor, $source, $target, $this->isReadOnly($target), $this->classPrefix);
+        $mapperMetadata->setAttributeChecking($this->attributeChecking);
+        $mapperMetadata->setDateTimeFormat($this->dateTimeFormat);
+
+        return $mapperMetadata;
+    }
+
+    private function isReadOnly(string $mappedType): bool
+    {
+        try {
+            $reflClass = new \ReflectionClass($mappedType);
+        } catch (\ReflectionException $e) {
+            $reflClass = null;
+        }
+        if (\PHP_VERSION_ID >= 80200 && null !== $reflClass && $reflClass->isReadOnly()) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/MapperGeneratorMetadataFactoryInterface.php
+++ b/src/Symfony/Component/AutoMapper/MapperGeneratorMetadataFactoryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper;
+
+/**
+ * Metadata factory, used to auto-registering new mapping without creating them.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+interface MapperGeneratorMetadataFactoryInterface
+{
+    public function create(MapperGeneratorMetadataRegistryInterface $autoMapperRegister, string $source, string $target): MapperGeneratorMetadataInterface;
+}

--- a/src/Symfony/Component/AutoMapper/MapperGeneratorMetadataInterface.php
+++ b/src/Symfony/Component/AutoMapper/MapperGeneratorMetadataInterface.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper;
+
+/**
+ * Stores metadata needed when generating a mapper.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+interface MapperGeneratorMetadataInterface extends MapperMetadataInterface
+{
+    /**
+     * Get mapper class name.
+     */
+    public function getMapperClassName(): string;
+
+    /**
+     * Get hash (unique key) for those metadata.
+     */
+    public function getHash(): string;
+
+    /**
+     * Get a list of callbacks to add for this mapper.
+     *
+     * @return callable[]
+     */
+    public function getCallbacks(): array;
+
+    /**
+     * Whether the target class has a constructor.
+     */
+    public function hasConstructor(): bool;
+
+    /**
+     * Whether we can use target constructor.
+     */
+    public function isConstructorAllowed(): bool;
+
+    /**
+     * Whether we should generate attributes checking.
+     */
+    public function shouldCheckAttributes(): bool;
+
+    /**
+     * If not using target constructor, allow to know if we can clone a empty target.
+     */
+    public function isTargetCloneable(): bool;
+
+    /**
+     * Whether the mapping can have circular reference.
+     *
+     * If not the case, allow to not generate code about circular references
+     */
+    public function canHaveCircularReference(): bool;
+}

--- a/src/Symfony/Component/AutoMapper/MapperGeneratorMetadataRegistryInterface.php
+++ b/src/Symfony/Component/AutoMapper/MapperGeneratorMetadataRegistryInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper;
+
+use Symfony\Component\AutoMapper\Transformer\TransformerFactoryInterface;
+
+/**
+ * Registry of metadata.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+interface MapperGeneratorMetadataRegistryInterface
+{
+    /**
+     * Register metadata.
+     */
+    public function register(MapperGeneratorMetadataInterface $configuration): void;
+
+    /**
+     * Get metadata for a source and a target.
+     */
+    public function getMetadata(string $source, string $target): ?MapperGeneratorMetadataInterface;
+
+    /**
+     * Add configuration for a given source & target.
+     */
+    public function addMapperConfiguration(MapperConfigurationInterface $mapperConfiguration): void;
+}

--- a/src/Symfony/Component/AutoMapper/MapperInterface.php
+++ b/src/Symfony/Component/AutoMapper/MapperInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper;
+
+/**
+ * Interface implemented by a single mapper.
+ *
+ * Each specific mapper should implement this interface
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+interface MapperInterface
+{
+    /**
+     * @param mixed $value   Value to map
+     * @param array $context Options mapper have access to
+     *
+     * @return mixed The mapped value
+     */
+    public function &map(mixed $value, array $context = []): mixed;
+}

--- a/src/Symfony/Component/AutoMapper/MapperMetadata.php
+++ b/src/Symfony/Component/AutoMapper/MapperMetadata.php
@@ -1,0 +1,279 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper;
+
+use Symfony\Component\AutoMapper\Extractor\MappingExtractorInterface;
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\Extractor\ReadAccessor;
+use Symfony\Component\AutoMapper\Extractor\ReadAccessorType;
+use Symfony\Component\AutoMapper\Transformer\CallbackTransformer;
+use Symfony\Component\AutoMapper\Transformer\DependentTransformerInterface;
+
+/**
+ * Mapper metadata.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class MapperMetadata implements MapperGeneratorMetadataInterface
+{
+    /** @var array<string, callable> */
+    private array $customMapping = [];
+
+    /** @var array<PropertyMapping> */
+    private array $propertiesMapping;
+
+    private ?string $className = null;
+
+    public bool $isConstructorAllowed = true;
+
+    private string $dateTimeFormat = \DateTimeInterface::RFC3339;
+
+    private bool $attributeChecking = true;
+
+    private ?\ReflectionClass $targetReflectionClass = null;
+
+    public function __construct(
+        private readonly MapperGeneratorMetadataRegistryInterface $metadataRegistry,
+        private readonly MappingExtractorInterface $mappingExtractor,
+        private readonly string $source,
+        private readonly string $target,
+        private readonly bool $isTargetReadOnlyClass,
+        private readonly string $classPrefix = 'Mapper_',
+    ) {
+    }
+
+    private function getCachedTargetReflectionClass(): \ReflectionClass
+    {
+        if (null === $this->targetReflectionClass) {
+            $this->targetReflectionClass = new \ReflectionClass($this->getTarget());
+        }
+
+        return $this->targetReflectionClass;
+    }
+
+    public function getPropertiesMapping(): array
+    {
+        if (!isset($this->propertiesMapping)) {
+            $this->buildPropertyMapping();
+        }
+
+        return $this->propertiesMapping;
+    }
+
+    public function getPropertyMapping(string $property): ?PropertyMapping
+    {
+        return $this->getPropertiesMapping()[$property] ?? null;
+    }
+
+    public function hasConstructor(): bool
+    {
+        if (!$this->isConstructorAllowed()) {
+            return false;
+        }
+
+        if (\in_array($this->target, ['array', \stdClass::class], true)) {
+            return false;
+        }
+
+        $reflection = $this->getCachedTargetReflectionClass();
+        $constructor = $reflection->getConstructor();
+
+        if (null === $constructor) {
+            return false;
+        }
+
+        $parameters = $constructor->getParameters();
+        $mandatoryParameters = [];
+
+        foreach ($parameters as $parameter) {
+            if (!$parameter->isOptional() && !$parameter->allowsNull()) {
+                $mandatoryParameters[] = $parameter;
+            }
+        }
+
+        if (!$mandatoryParameters) {
+            return true;
+        }
+
+        foreach ($mandatoryParameters as $mandatoryParameter) {
+            $readAccessor = $this->mappingExtractor->getReadAccessor($this->source, $this->target, $mandatoryParameter->getName());
+
+            if (null === $readAccessor) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function isTargetCloneable(): bool
+    {
+        try {
+            $reflection = $this->getCachedTargetReflectionClass();
+
+            return $reflection->isCloneable() && !$reflection->hasMethod('__clone');
+        } catch (\ReflectionException $e) {
+            // if we have a \ReflectionException, then we can't clone target
+            return false;
+        }
+    }
+
+    public function canHaveCircularReference(): bool
+    {
+        $checked = [];
+
+        return $this->checkCircularMapperConfiguration($this, $checked);
+    }
+
+    public function getMapperClassName(): string
+    {
+        if (null !== $this->className) {
+            return $this->className;
+        }
+
+        return $this->className = sprintf('%s%s_%s', $this->classPrefix, str_replace('\\', '_', $this->source), str_replace('\\', '_', $this->target));
+    }
+
+    public function getHash(): string
+    {
+        $hash = '';
+
+        if (!\in_array($this->source, ['array', \stdClass::class], true) && class_exists($this->source)) {
+            $reflection = new \ReflectionClass($this->source);
+            $hash .= filemtime($reflection->getFileName());
+        }
+
+        if (!\in_array($this->target, ['array', \stdClass::class], true)) {
+            $reflection = $this->getCachedTargetReflectionClass();
+            $hash .= filemtime($reflection->getFileName());
+        }
+
+        return $hash;
+    }
+
+    public function isConstructorAllowed(): bool
+    {
+        return $this->isConstructorAllowed;
+    }
+
+    public function getSource(): string
+    {
+        return $this->source;
+    }
+
+    public function getTarget(): string
+    {
+        return $this->target;
+    }
+
+    public function getDateTimeFormat(): string
+    {
+        return $this->dateTimeFormat;
+    }
+
+    public function getCallbacks(): array
+    {
+        return $this->customMapping;
+    }
+
+    public function shouldCheckAttributes(): bool
+    {
+        return $this->attributeChecking;
+    }
+
+    public function isTargetReadOnlyClass(): bool
+    {
+        return $this->isTargetReadOnlyClass;
+    }
+
+    /**
+     * Set DateTime format to use when generating a mapper.
+     */
+    public function setDateTimeFormat(string $dateTimeFormat): void
+    {
+        $this->dateTimeFormat = $dateTimeFormat;
+    }
+
+    /**
+     * Whether or not the constructor should be used.
+     */
+    public function setConstructorAllowed(bool $isConstructorAllowed): void
+    {
+        $this->isConstructorAllowed = $isConstructorAllowed;
+    }
+
+    /**
+     * Set a callable to use when mapping a specific property.
+     */
+    public function forMember(string $property, callable $callback): void
+    {
+        $this->customMapping[$property] = $callback;
+    }
+
+    /**
+     * Whether or not attribute checking code should be generated.
+     */
+    public function setAttributeChecking(bool $attributeChecking): void
+    {
+        $this->attributeChecking = $attributeChecking;
+    }
+
+    private function buildPropertyMapping(): void
+    {
+        $this->propertiesMapping = [];
+
+        foreach ($this->mappingExtractor->getPropertiesMapping($this) as $propertyMapping) {
+            $this->propertiesMapping[$propertyMapping->property] = $propertyMapping;
+        }
+
+        foreach ($this->customMapping as $property => $callback) {
+            $this->propertiesMapping[$property] = new PropertyMapping(
+                new ReadAccessor(ReadAccessorType::SOURCE, $property),
+                $this->mappingExtractor->getWriteMutator($this->source, $this->target, $property),
+                null,
+                new CallbackTransformer($property),
+                $property,
+                false
+            );
+        }
+    }
+
+    private function checkCircularMapperConfiguration(MapperGeneratorMetadataInterface $configuration, &$checked): bool
+    {
+        foreach ($configuration->getPropertiesMapping() as $propertyMapping) {
+            if (!$propertyMapping->transformer instanceof DependentTransformerInterface) {
+                continue;
+            }
+
+            foreach ($propertyMapping->transformer->getDependencies() as $dependency) {
+                if (isset($checked[$dependency->name])) {
+                    continue;
+                }
+
+                $checked[$dependency->name] = true;
+
+                if ($dependency->source === $this->getSource() && $dependency->target === $this->getTarget()) {
+                    return true;
+                }
+
+                $subConfiguration = $this->metadataRegistry->getMetadata($dependency->source, $dependency->target);
+
+                if (null !== $subConfiguration && true === $this->checkCircularMapperConfiguration($subConfiguration, $checked)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/MapperMetadataInterface.php
+++ b/src/Symfony/Component/AutoMapper/MapperMetadataInterface.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper;
+
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+
+/**
+ * Stores metadata needed for mapping data.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+interface MapperMetadataInterface
+{
+    /**
+     * Get the source type mapped.
+     */
+    public function getSource(): string;
+
+    /**
+     * Get the target type mapped.
+     */
+    public function getTarget(): string;
+
+    /**
+     * Check if the target is a read-only class.
+     */
+    public function isTargetReadOnlyClass(): bool;
+
+    /**
+     * Get properties to map between source and target.
+     *
+     * @return PropertyMapping[]
+     */
+    public function getPropertiesMapping(): array;
+
+    /**
+     * Get property to map by name, or null if not mapped.
+     */
+    public function getPropertyMapping(string $property): ?PropertyMapping;
+
+    /**
+     * Get date time format to use when mapping date time to string.
+     */
+    public function getDateTimeFormat(): string;
+}

--- a/src/Symfony/Component/AutoMapper/Normalizer/AutoMapperNormalizer.php
+++ b/src/Symfony/Component/AutoMapper/Normalizer/AutoMapperNormalizer.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Normalizer;
+
+use Symfony\Component\AutoMapper\AutoMapperInterface;
+use Symfony\Component\AutoMapper\AutoMapperRegistryInterface;
+use Symfony\Component\AutoMapper\MapperContext;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Bridge for symfony/serializer.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class AutoMapperNormalizer implements NormalizerInterface, DenormalizerInterface
+{
+    private const SERIALIZER_CONTEXT_MAPPING = [
+        AbstractNormalizer::GROUPS => MapperContext::GROUPS,
+        AbstractNormalizer::ATTRIBUTES => MapperContext::ALLOWED_ATTRIBUTES,
+        AbstractNormalizer::IGNORED_ATTRIBUTES => MapperContext::IGNORED_ATTRIBUTES,
+        AbstractNormalizer::OBJECT_TO_POPULATE => MapperContext::TARGET_TO_POPULATE,
+        AbstractNormalizer::CIRCULAR_REFERENCE_LIMIT => MapperContext::CIRCULAR_REFERENCE_LIMIT,
+        AbstractNormalizer::CIRCULAR_REFERENCE_HANDLER => MapperContext::CIRCULAR_REFERENCE_HANDLER,
+    ];
+
+    public function __construct(
+        private readonly AutoMapperInterface&AutoMapperRegistryInterface $autoMapper,
+    ) {
+    }
+
+    public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        return $this->autoMapper->map($object, 'array', $this->createAutoMapperContext($context));
+    }
+
+    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    {
+        return $this->autoMapper->map($data, $type, $this->createAutoMapperContext($context));
+    }
+
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+    {
+        if (!\is_object($data) || $data instanceof \stdClass) {
+            return false;
+        }
+
+        return $this->autoMapper->hasMapper($data::class, 'array');
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    {
+        return $this->autoMapper->hasMapper('array', $type);
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return ['object' => true];
+    }
+
+    private function createAutoMapperContext(array $serializerContext = []): array
+    {
+        $context = [];
+
+        foreach (self::SERIALIZER_CONTEXT_MAPPING as $serializerContextName => $autoMapperContextName) {
+            $context[$autoMapperContextName] = $serializerContext[$serializerContextName] ?? null;
+            unset($serializerContext[$serializerContextName]);
+        }
+
+        if (\array_key_exists(AbstractNormalizer::DEFAULT_CONSTRUCTOR_ARGUMENTS, $serializerContext) && is_iterable($serializerContext[AbstractNormalizer::DEFAULT_CONSTRUCTOR_ARGUMENTS])) {
+            foreach ($serializerContext[AbstractNormalizer::DEFAULT_CONSTRUCTOR_ARGUMENTS] as $class => $keyArgs) {
+                foreach ($keyArgs as $key => $value) {
+                    $context[MapperContext::CONSTRUCTOR_ARGUMENTS][$class][$key] = $value;
+                }
+            }
+
+            unset($serializerContext[AbstractNormalizer::DEFAULT_CONSTRUCTOR_ARGUMENTS]);
+        }
+
+        return $context + $serializerContext;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/README.md
+++ b/src/Symfony/Component/AutoMapper/README.md
@@ -1,0 +1,58 @@
+AutoMapper Component
+===============
+
+Taken from [AutoMapper/AutoMapper](https://github.com/AutoMapper/AutoMapper)
+
+> AutoMapper is a simple little library built to solve a deceptively complex
+> problem - getting rid of code that mapped one object to another. This type
+> of code is rather dreary and boring to write, so why not invent a tool to
+> do it for us?
+
+In PHP libraries and application mapping from one object to another is
+fairly common:
+
+* ObjectNormalizer / GetSetMethodNormalizer in Serializer component
+* Mapping request data to object in Form component
+* Hydrate object from SQL results in Doctrine
+* Migrating legacy data to new model
+* Mapping from database model to DTO objects (API / CQRS / ...)
+* ...
+
+The goal of this component is to offer an abstraction on top of this subject.
+For that goal it provides an unique interface (other code is only
+implementation detail):
+
+```php
+interface AutoMapperInterface
+{
+    /**
+     * Map data from to target.
+     *
+     * @param array|object        $source  Any data object, which may be an object or an array
+     * @param string|array|object $target  To which type of data, or data, the source should be mapped
+     * @param Context             $context Options mappers have access to
+     *
+     * @return array|object The mapped object
+     */
+    public function map($source, $target, Context $context = null);
+}
+```
+
+The source is from where the data comes from, it can be either an array
+or an object.
+The target is where the data should be mapped to, it can be either a string
+(representing a type: array or class name) or directly an array or object
+(in that case construction of the object is avoided).
+
+Current implementation handle all of those possibilities at the exception
+of the mapping from a dynamic object (array / stdClass) to another dynamic
+object.
+
+Resources
+---------
+
+ * [Documentation](https://symfony.com/doc/current/components/automapper/introduction.html)
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/symfony/issues) and
+   [send Pull Requests](https://github.com/symfony/symfony/pulls)
+   in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/AutoMapper/Tests/AutoMapperBase.php
+++ b/src/Symfony/Component/AutoMapper/Tests/AutoMapperBase.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Symfony\Component\AutoMapper\AutoMapper;
+use Symfony\Component\AutoMapper\AutoMapperInterface;
+use Symfony\Component\AutoMapper\Generator\Generator;
+use Symfony\Component\AutoMapper\Loader\ClassLoaderInterface;
+use Symfony\Component\AutoMapper\Loader\FileLoader;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+abstract class AutoMapperBase extends TestCase
+{
+    protected AutoMapperInterface $autoMapper;
+    protected ClassLoaderInterface $loader;
+
+    protected function setUp(): void
+    {
+        unset($this->autoMapper, $this->loader);
+        $this->buildAutoMapper();
+    }
+
+    protected function buildAutoMapper(array $customTransformerFactories = [], bool $allowReadOnlyTargetToPopulate = false): AutoMapperInterface
+    {
+        $fs = new Filesystem();
+        $fs->remove(__DIR__ . '/cache/');
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+
+        $this->loader = new FileLoader(new Generator(
+            (new ParserFactory())->create(ParserFactory::PREFER_PHP7),
+            new ClassDiscriminatorFromClassMetadata($classMetadataFactory),
+            $allowReadOnlyTargetToPopulate,
+        ), __DIR__ . '/cache');
+
+        return $this->autoMapper = AutoMapper::create(true, $this->loader, customTransformerFactories: $customTransformerFactories);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/AutoMapperTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/AutoMapperTest.php
@@ -1,0 +1,1112 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests;
+
+use Symfony\Component\AutoMapper\AutoMapper;
+use Symfony\Component\AutoMapper\Exception\CircularReferenceException;
+use Symfony\Component\AutoMapper\Exception\NoMappingFoundException;
+use Symfony\Component\AutoMapper\Exception\ReadOnlyTargetException;
+use Symfony\Component\AutoMapper\MapperContext;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
+use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class AutoMapperTest extends AutoMapperBase
+{
+    public function testAutoMapping(): void
+    {
+        $userMetadata = $this->autoMapper->getMetadata(Fixtures\User::class, Fixtures\UserDTO::class);
+        $userMetadata->forMember('yearOfBirth', function (Fixtures\User $user) {
+            return ((int) date('Y')) - ((int) $user->age);
+        });
+
+        $address = new Fixtures\Address();
+        $address->setCity('Toulon');
+        $user = new Fixtures\User(1, 'yolo', '13');
+        $user->address = $address;
+        $user->addresses[] = $address;
+        $user->money = 20.10;
+
+        /** @var Fixtures\UserDTO $userDto */
+        $userDto = $this->autoMapper->map($user, Fixtures\UserDTO::class);
+
+        self::assertInstanceOf(Fixtures\UserDTO::class, $userDto);
+        self::assertSame(1, $userDto->id);
+        self::assertSame('yolo', $userDto->getName());
+        self::assertSame(13, $userDto->age);
+        self::assertSame(((int) date('Y')) - 13, $userDto->yearOfBirth);
+        self::assertCount(1, $userDto->addresses);
+        self::assertInstanceOf(Fixtures\AddressDTO::class, $userDto->address);
+        self::assertInstanceOf(Fixtures\AddressDTO::class, $userDto->addresses[0]);
+        self::assertSame('Toulon', $userDto->address->city);
+        self::assertSame('Toulon', $userDto->addresses[0]->city);
+        self::assertIsArray($userDto->money);
+        self::assertCount(1, $userDto->money);
+        self::assertSame(20.10, $userDto->money[0]);
+    }
+
+    public function testAutoMapperFromArray(): void
+    {
+        $user = [
+            'id' => 1,
+            'address' => [
+                'city' => 'Toulon',
+            ],
+            'createdAt' => '1987-04-30T06:00:00Z',
+        ];
+
+        /** @var Fixtures\UserDTO $userDto */
+        $userDto = $this->autoMapper->map($user, Fixtures\UserDTO::class);
+
+        self::assertInstanceOf(Fixtures\UserDTO::class, $userDto);
+        self::assertEquals(1, $userDto->id);
+        self::assertInstanceOf(Fixtures\AddressDTO::class, $userDto->address);
+        self::assertSame('Toulon', $userDto->address->city);
+        self::assertInstanceOf(\DateTimeInterface::class, $userDto->createdAt);
+        self::assertEquals(1987, $userDto->createdAt->format('Y'));
+    }
+
+    public function testAutoMapperFromArrayCustomDateTime(): void
+    {
+        $dateTime = \DateTime::createFromFormat(\DateTime::RFC3339, '1987-04-30T06:00:00Z');
+        $customFormat = 'U';
+        $user = [
+            'id' => 1,
+            'address' => [
+                'city' => 'Toulon',
+            ],
+            'createdAt' => $dateTime->format($customFormat),
+        ];
+
+        $autoMapper = AutoMapper::create(true, $this->loader, null, 'CustomDateTime_');
+        $configuration = $autoMapper->getMetadata('array', Fixtures\UserDTO::class);
+        $configuration->setDateTimeFormat($customFormat);
+
+        /** @var Fixtures\UserDTO $userDto */
+        $userDto = $autoMapper->map($user, Fixtures\UserDTO::class);
+
+        self::assertInstanceOf(Fixtures\UserDTO::class, $userDto);
+        self::assertEquals($dateTime->format($customFormat), $userDto->createdAt->format($customFormat));
+    }
+
+    public function testAutoMapperToArray(): void
+    {
+        $address = new Fixtures\Address();
+        $address->setCity('Toulon');
+        $user = new Fixtures\User(1, 'yolo', '13');
+        $user->address = $address;
+        $user->addresses[] = $address;
+
+        $userData = $this->autoMapper->map($user, 'array');
+
+        self::assertIsArray($userData);
+        self::assertEquals(1, $userData['id']);
+        self::assertIsArray($userData['address']);
+        self::assertIsString($userData['createdAt']);
+    }
+
+    public function testAutoMapperFromStdObject(): void
+    {
+        $user = new \stdClass();
+        $user->id = 1;
+
+        /** @var Fixtures\UserDTO $userDto */
+        $userDto = $this->autoMapper->map($user, Fixtures\UserDTO::class);
+
+        self::assertInstanceOf(Fixtures\UserDTO::class, $userDto);
+        self::assertEquals(1, $userDto->id);
+    }
+
+    public function testAutoMapperToStdObject(): void
+    {
+        $userDto = new Fixtures\UserDTO();
+        $userDto->id = 1;
+
+        $user = $this->autoMapper->map($userDto, \stdClass::class);
+
+        self::assertInstanceOf(\stdClass::class, $user);
+        self::assertEquals(1, $user->id);
+    }
+
+    public function testAutoMapperStdObjectToStdObject(): void
+    {
+        $user = new \stdClass();
+        $user->id = 1;
+        $nestedStd = new \stdClass();
+        $nestedStd->id = 2;
+        $user->nestedStd = $nestedStd;
+        $userStd = $this->autoMapper->map($user, \stdClass::class);
+
+        self::assertInstanceOf(\stdClass::class, $userStd);
+        self::assertNotSame($user, $userStd);
+        self::assertNotSame($user->nestedStd, $userStd->nestedStd);
+        self::assertEquals($user, $userStd);
+    }
+
+    public function testNotReadable(): void
+    {
+        $autoMapper = AutoMapper::create(false, $this->loader, null, 'NotReadable_');
+        $address = new Fixtures\Address();
+        $address->setCity('test');
+
+        $addressArray = $autoMapper->map($address, 'array');
+
+        self::assertIsArray($addressArray);
+        self::assertArrayNotHasKey('city', $addressArray);
+
+        $addressMapped = $autoMapper->map($address, Fixtures\Address::class);
+
+        self::assertInstanceOf(Fixtures\Address::class, $addressMapped);
+
+        $property = (new \ReflectionClass($addressMapped))->getProperty('city');
+        $property->setAccessible(true);
+
+        $city = $property->getValue($addressMapped);
+
+        self::assertNull($city);
+    }
+
+    public function testNoTypes(): void
+    {
+        $autoMapper = AutoMapper::create(false, $this->loader, null, 'NotReadable_');
+        $address = new Fixtures\AddressNoTypes();
+        $address->city = 'test';
+
+        $addressArray = $autoMapper->map($address, 'array');
+
+        self::assertIsArray($addressArray);
+        self::assertArrayHasKey('city', $addressArray);
+        self::assertEquals('test', $addressArray['city']);
+    }
+
+    public function testNoTransformer(): void
+    {
+        $addressFoo = new Fixtures\AddressFoo();
+        $addressFoo->city = new Fixtures\CityFoo();
+        $addressFoo->city->name = 'test';
+
+        $addressBar = $this->autoMapper->map($addressFoo, Fixtures\AddressBar::class);
+
+        self::assertInstanceOf(Fixtures\AddressBar::class, $addressBar);
+        self::assertNull($addressBar->city);
+    }
+
+    public function testNoProperties(): void
+    {
+        $noProperties = new Fixtures\FooNoProperties();
+        $noPropertiesMapped = $this->autoMapper->map($noProperties, Fixtures\FooNoProperties::class);
+
+        self::assertInstanceOf(Fixtures\FooNoProperties::class, $noPropertiesMapped);
+        self::assertNotSame($noProperties, $noPropertiesMapped);
+    }
+
+    public function testGroupsSourceTarget(): void
+    {
+        $foo = new Fixtures\Foo();
+        $foo->setId(10);
+
+        $bar = $this->autoMapper->map($foo, Fixtures\Bar::class, [MapperContext::GROUPS => ['group2']]);
+
+        self::assertInstanceOf(Fixtures\Bar::class, $bar);
+        self::assertEquals(10, $bar->getId());
+
+        $bar = $this->autoMapper->map($foo, Fixtures\Bar::class, [MapperContext::GROUPS => ['group1', 'group3']]);
+
+        self::assertInstanceOf(Fixtures\Bar::class, $bar);
+        self::assertEquals(10, $bar->getId());
+
+        $bar = $this->autoMapper->map($foo, Fixtures\Bar::class, [MapperContext::GROUPS => ['group1']]);
+
+        self::assertInstanceOf(Fixtures\Bar::class, $bar);
+        self::assertNull($bar->getId());
+
+        $bar = $this->autoMapper->map($foo, Fixtures\Bar::class, [MapperContext::GROUPS => []]);
+
+        self::assertInstanceOf(Fixtures\Bar::class, $bar);
+        self::assertNull($bar->getId());
+
+        $bar = $this->autoMapper->map($foo, Fixtures\Bar::class);
+
+        self::assertInstanceOf(Fixtures\Bar::class, $bar);
+        self::assertNull($bar->getId());
+    }
+
+    public function testGroupsToArray(): void
+    {
+        $foo = new Fixtures\Foo();
+        $foo->setId(10);
+
+        $fooArray = $this->autoMapper->map($foo, 'array', [MapperContext::GROUPS => ['group1']]);
+
+        self::assertIsArray($fooArray);
+        self::assertEquals(10, $fooArray['id']);
+
+        $fooArray = $this->autoMapper->map($foo, 'array', [MapperContext::GROUPS => []]);
+
+        self::assertIsArray($fooArray);
+        self::assertArrayNotHasKey('id', $fooArray);
+
+        $fooArray = $this->autoMapper->map($foo, 'array');
+
+        self::assertIsArray($fooArray);
+        self::assertArrayNotHasKey('id', $fooArray);
+    }
+
+    public function testDeepCloning(): void
+    {
+        $nodeA = new Fixtures\Node();
+        $nodeB = new Fixtures\Node();
+        $nodeB->parent = $nodeA;
+        $nodeC = new Fixtures\Node();
+        $nodeC->parent = $nodeB;
+        $nodeA->parent = $nodeC;
+
+        $newNode = $this->autoMapper->map($nodeA, Fixtures\Node::class);
+
+        self::assertInstanceOf(Fixtures\Node::class, $newNode);
+        self::assertNotSame($newNode, $nodeA);
+        self::assertInstanceOf(Fixtures\Node::class, $newNode->parent);
+        self::assertNotSame($newNode->parent, $nodeA->parent);
+        self::assertInstanceOf(Fixtures\Node::class, $newNode->parent->parent);
+        self::assertNotSame($newNode->parent->parent, $nodeA->parent->parent);
+        self::assertInstanceOf(Fixtures\Node::class, $newNode->parent->parent->parent);
+        self::assertSame($newNode, $newNode->parent->parent->parent);
+    }
+
+    public function testDeepCloningArray(): void
+    {
+        $nodeA = new Fixtures\Node();
+        $nodeB = new Fixtures\Node();
+        $nodeB->parent = $nodeA;
+        $nodeC = new Fixtures\Node();
+        $nodeC->parent = $nodeB;
+        $nodeA->parent = $nodeC;
+
+        $newNode = $this->autoMapper->map($nodeA, 'array');
+
+        self::assertIsArray($newNode);
+        self::assertIsArray($newNode['parent']);
+        self::assertIsArray($newNode['parent']['parent']);
+        self::assertIsArray($newNode['parent']['parent']['parent']);
+        self::assertSame($newNode, $newNode['parent']['parent']['parent']);
+    }
+
+    public function testCircularReferenceDeep(): void
+    {
+        $foo = new Fixtures\CircularFoo();
+        $bar = new Fixtures\CircularBar();
+        $baz = new Fixtures\CircularBaz();
+
+        $foo->bar = $bar;
+        $bar->baz = $baz;
+        $baz->foo = $foo;
+
+        $newFoo = $this->autoMapper->map($foo, Fixtures\CircularFoo::class);
+
+        self::assertNotSame($foo, $newFoo);
+        self::assertNotNull($newFoo->bar);
+        self::assertNotSame($bar, $newFoo->bar);
+        self::assertNotNull($newFoo->bar->baz);
+        self::assertNotSame($baz, $newFoo->bar->baz);
+        self::assertNotNull($newFoo->bar->baz->foo);
+        self::assertSame($newFoo, $newFoo->bar->baz->foo);
+    }
+
+    public function testCircularReferenceArray(): void
+    {
+        $nodeA = new Fixtures\Node();
+        $nodeB = new Fixtures\Node();
+
+        $nodeA->childs[] = $nodeB;
+        $nodeB->childs[] = $nodeA;
+
+        $newNode = $this->autoMapper->map($nodeA, 'array');
+
+        self::assertIsArray($newNode);
+        self::assertIsArray($newNode['childs'][0]);
+        self::assertIsArray($newNode['childs'][0]['childs'][0]);
+        self::assertSame($newNode, $newNode['childs'][0]['childs'][0]);
+    }
+
+    public function testPrivate(): void
+    {
+        $user = new Fixtures\PrivateUser(10, 'foo', 'bar');
+        /** @var Fixtures\PrivateUserDTO $userDto */
+        $userDto = $this->autoMapper->map($user, Fixtures\PrivateUserDTO::class);
+
+        self::assertInstanceOf(Fixtures\PrivateUserDTO::class, $userDto);
+        self::assertSame(10, $userDto->getId());
+        self::assertSame('foo', $userDto->getFirstName());
+        self::assertSame('bar', $userDto->getLastName());
+    }
+
+    public function testConstructor(): void
+    {
+        $autoMapper = AutoMapper::create(false, $this->loader);
+
+        $user = new Fixtures\UserDTO();
+        $user->id = 10;
+        $user->setName('foo');
+        $user->age = 3;
+        /** @var Fixtures\UserConstructorDTO $userDto */
+        $userDto = $autoMapper->map($user, Fixtures\UserConstructorDTO::class);
+
+        self::assertInstanceOf(Fixtures\UserConstructorDTO::class, $userDto);
+        self::assertSame('10', $userDto->getId());
+        self::assertSame('foo', $userDto->getName());
+        self::assertSame(3, $userDto->getAge());
+        self::assertTrue($userDto->getConstructor());
+    }
+
+    public function testConstructorNotAllowed(): void
+    {
+        $autoMapper = AutoMapper::create(true, $this->loader, null, 'NotAllowedMapper_');
+        $configuration = $autoMapper->getMetadata(Fixtures\UserDTO::class, Fixtures\UserConstructorDTO::class);
+        $configuration->setConstructorAllowed(false);
+
+        $user = new Fixtures\UserDTO();
+        $user->id = 10;
+        $user->setName('foo');
+        $user->age = 3;
+
+        /** @var Fixtures\UserConstructorDTO $userDto */
+        $userDto = $autoMapper->map($user, Fixtures\UserConstructorDTO::class);
+
+        self::assertInstanceOf(Fixtures\UserConstructorDTO::class, $userDto);
+        self::assertSame('10', $userDto->getId());
+        self::assertSame('foo', $userDto->getName());
+        self::assertSame(3, $userDto->getAge());
+        self::assertFalse($userDto->getConstructor());
+    }
+
+    public function testConstructorWithDefault(): void
+    {
+        $user = new Fixtures\UserDTONoAge();
+        $user->id = 10;
+        $user->name = 'foo';
+        /** @var Fixtures\UserConstructorDTO $userDto */
+        $userDto = $this->autoMapper->map($user, Fixtures\UserConstructorDTO::class);
+
+        self::assertInstanceOf(Fixtures\UserConstructorDTO::class, $userDto);
+        self::assertSame('10', $userDto->getId());
+        self::assertSame('foo', $userDto->getName());
+        self::assertSame(30, $userDto->getAge());
+    }
+
+    public function testConstructorDisable(): void
+    {
+        $user = new Fixtures\UserDTONoName();
+        $user->id = 10;
+        /** @var Fixtures\UserConstructorDTO $userDto */
+        $userDto = $this->autoMapper->map($user, Fixtures\UserConstructorDTO::class);
+
+        self::assertInstanceOf(Fixtures\UserConstructorDTO::class, $userDto);
+        self::assertSame('10', $userDto->getId());
+        self::assertNull($userDto->getName());
+        self::assertNull($userDto->getAge());
+    }
+
+    public function testMaxDepth(): void
+    {
+        $foo = new Fixtures\FooMaxDepth(0, new Fixtures\FooMaxDepth(1, new Fixtures\FooMaxDepth(2, new Fixtures\FooMaxDepth(3, new Fixtures\FooMaxDepth(4)))));
+        $fooArray = $this->autoMapper->map($foo, 'array');
+
+        self::assertNotNull($fooArray['child']);
+        self::assertNotNull($fooArray['child']['child']);
+        self::assertFalse(isset($fooArray['child']['child']['child']));
+    }
+
+    public function testObjectToPopulate(): void
+    {
+        $configurationUser = $this->autoMapper->getMetadata(Fixtures\User::class, Fixtures\UserDTO::class);
+        $configurationUser->forMember('yearOfBirth', function (Fixtures\User $user) {
+            return ((int) date('Y')) - ((int) $user->age);
+        });
+
+        $user = new Fixtures\User(1, 'yolo', '13');
+        $userDtoToPopulate = new Fixtures\UserDTO();
+
+        $userDto = $this->autoMapper->map($user, Fixtures\UserDTO::class, [MapperContext::TARGET_TO_POPULATE => $userDtoToPopulate]);
+
+        self::assertSame($userDtoToPopulate, $userDto);
+    }
+
+    public function testObjectToPopulateWithoutContext(): void
+    {
+        $configurationUser = $this->autoMapper->getMetadata(Fixtures\User::class, Fixtures\UserDTO::class);
+        $configurationUser->forMember('yearOfBirth', function (Fixtures\User $user) {
+            return ((int) date('Y')) - ((int) $user->age);
+        });
+
+        $user = new Fixtures\User(1, 'yolo', '13');
+        $userDtoToPopulate = new Fixtures\UserDTO();
+
+        $userDto = $this->autoMapper->map($user, $userDtoToPopulate);
+
+        self::assertSame($userDtoToPopulate, $userDto);
+    }
+
+    public function testArrayToPopulate(): void
+    {
+        $configurationUser = $this->autoMapper->getMetadata(Fixtures\User::class, Fixtures\UserDTO::class);
+        $configurationUser->forMember('yearOfBirth', function (Fixtures\User $user) {
+            return ((int) date('Y')) - ((int) $user->age);
+        });
+
+        $user = new Fixtures\User(1, 'yolo', '13');
+        $array = [];
+        $arrayMapped = $this->autoMapper->map($user, $array);
+
+        self::assertIsArray($arrayMapped);
+        self::assertSame(1, $arrayMapped['id']);
+        self::assertSame('yolo', $arrayMapped['name']);
+        self::assertSame('13', $arrayMapped['age']);
+    }
+
+    public function testCircularReferenceLimitOnContext(): void
+    {
+        $nodeA = new Fixtures\Node();
+        $nodeA->parent = $nodeA;
+
+        $context = new MapperContext();
+        $context->setCircularReferenceLimit(1);
+
+        $this->expectException(CircularReferenceException::class);
+
+        $this->autoMapper->map($nodeA, 'array', $context->toArray());
+    }
+
+    public function testCircularReferenceLimitOnMapper(): void
+    {
+        $nodeA = new Fixtures\Node();
+        $nodeA->parent = $nodeA;
+
+        $mapper = $this->autoMapper->getMapper(Fixtures\Node::class, 'array');
+        $mapper->setCircularReferenceLimit(1);
+
+        $this->expectException(CircularReferenceException::class);
+
+        $mapper->map($nodeA);
+    }
+
+    public function testCircularReferenceHandlerOnContext(): void
+    {
+        $nodeA = new Fixtures\Node();
+        $nodeA->parent = $nodeA;
+
+        $context = new MapperContext();
+        $context->setCircularReferenceHandler(function () {
+            return 'foo';
+        });
+
+        $nodeArray = $this->autoMapper->map($nodeA, 'array', $context->toArray());
+
+        self::assertSame('foo', $nodeArray['parent']);
+    }
+
+    public function testCircularReferenceHandlerOnMapper(): void
+    {
+        $nodeA = new Fixtures\Node();
+        $nodeA->parent = $nodeA;
+
+        $mapper = $this->autoMapper->getMapper(Fixtures\Node::class, 'array');
+        $mapper->setCircularReferenceHandler(function () {
+            return 'foo';
+        });
+
+        $nodeArray = $mapper->map($nodeA);
+
+        self::assertSame('foo', $nodeArray['parent']);
+    }
+
+    public function testAllowedAttributes(): void
+    {
+        $configurationUser = $this->autoMapper->getMetadata(Fixtures\User::class, Fixtures\UserDTO::class);
+        $configurationUser->forMember('yearOfBirth', function (Fixtures\User $user) {
+            return ((int) date('Y')) - ((int) $user->age);
+        });
+
+        $user = new Fixtures\User(1, 'yolo', '13');
+
+        $userDto = $this->autoMapper->map($user, Fixtures\UserDTO::class, [MapperContext::ALLOWED_ATTRIBUTES => ['id', 'age']]);
+
+        self::assertNull($userDto->getName());
+    }
+
+    public function testIgnoredAttributes(): void
+    {
+        $configurationUser = $this->autoMapper->getMetadata(Fixtures\User::class, Fixtures\UserDTO::class);
+        $configurationUser->forMember('yearOfBirth', function (Fixtures\User $user) {
+            return ((int) date('Y')) - ((int) $user->age);
+        });
+
+        $user = new Fixtures\User(1, 'yolo', '13');
+        $userDto = $this->autoMapper->map($user, Fixtures\UserDTO::class, [MapperContext::IGNORED_ATTRIBUTES => ['name']]);
+
+        self::assertNull($userDto->getName());
+    }
+
+    public function testMappingWithTargetObjectWithNoObjectToPopulate(): void
+    {
+        $configurationUser = $this->autoMapper->getMetadata(Fixtures\User::class, Fixtures\UserDTOMerged::class);
+        $configurationUser->forMember('properties', function (Fixtures\User $user, Fixtures\UserDTOMerged $target) {
+            return array_merge($target->getProperties(), [
+                'name' => $user->name,
+                'age' => $user->age,
+            ]);
+        });
+
+        $user = new Fixtures\User(1, 'yolo', '13');
+        $userDto = $this->autoMapper->map($user, Fixtures\UserDTOMerged::class);
+
+        self::assertArrayHasKey('name', $userDto->getProperties());
+        self::assertArrayHasKey('age', $userDto->getProperties());
+        self::assertArrayNotHasKey('gender', $userDto->getProperties());
+    }
+
+    public function testMappingWithTargetObjectWithObjectToPopulate(): void
+    {
+        $configurationUser = $this->autoMapper->getMetadata(Fixtures\User::class, Fixtures\UserDTOMerged::class);
+        $configurationUser->forMember('properties', function (Fixtures\User $user, Fixtures\UserDTOMerged $target) {
+            return array_merge($target->getProperties(), [
+                'name' => $user->name,
+                'age' => $user->age,
+            ]);
+        });
+
+        $user = new Fixtures\User(1, 'yolo', '13');
+        $dto = new Fixtures\UserDTOMerged();
+        $dto->setProperties(['gender' => 1]);
+
+        $userDto = $this->autoMapper->map($user, $dto);
+
+        self::assertArrayHasKey('name', $userDto->getProperties());
+        self::assertArrayHasKey('age', $userDto->getProperties());
+        self::assertArrayHasKey('gender', $userDto->getProperties());
+    }
+
+    public function testNameConverter(): void
+    {
+        if (Kernel::MAJOR_VERSION < 6) {
+            $nameConverter = new class() implements AdvancedNameConverterInterface {
+                public function normalize(string $propertyName, ?string $class = null, ?string $format = null, array $context = []): string
+                {
+                    if ('id' === $propertyName) {
+                        return '@id';
+                    }
+
+                    return $propertyName;
+                }
+
+                public function denormalize(string $propertyName, ?string $class = null, ?string $format = null, array $context = []): string
+                {
+                    if ('@id' === $propertyName) {
+                        return 'id';
+                    }
+
+                    return $propertyName;
+                }
+            };
+        } else {
+            $nameConverter = new class() implements AdvancedNameConverterInterface {
+                public function normalize(string $propertyName, ?string $class = null, ?string $format = null, array $context = []): string
+                {
+                    if ('id' === $propertyName) {
+                        return '@id';
+                    }
+
+                    return $propertyName;
+                }
+
+                public function denormalize(string $propertyName, ?string $class = null, ?string $format = null, array $context = []): string
+                {
+                    if ('@id' === $propertyName) {
+                        return 'id';
+                    }
+
+                    return $propertyName;
+                }
+            };
+        }
+
+        $autoMapper = AutoMapper::create(true, null, $nameConverter, 'Mapper2_');
+        $user = new Fixtures\User(1, 'yolo', '13');
+
+        $userArray = $autoMapper->map($user, 'array');
+
+        self::assertIsArray($userArray);
+        self::assertArrayHasKey('@id', $userArray);
+        self::assertSame(1, $userArray['@id']);
+    }
+
+    public function testDefaultArguments(): void
+    {
+        $user = new Fixtures\UserDTONoAge();
+        $user->id = 10;
+        $user->name = 'foo';
+
+        $context = new MapperContext();
+        $context->setConstructorArgument(Fixtures\UserConstructorDTO::class, 'age', 50);
+
+        /** @var Fixtures\UserConstructorDTO $userDto */
+        $userDto = $this->autoMapper->map($user, Fixtures\UserConstructorDTO::class, $context->toArray());
+
+        self::assertInstanceOf(Fixtures\UserConstructorDTO::class, $userDto);
+        self::assertSame(50, $userDto->getAge());
+    }
+
+    public function testDiscriminator(): void
+    {
+        $data = [
+            'type' => 'cat',
+        ];
+
+        $pet = $this->autoMapper->map($data, Fixtures\Pet::class);
+
+        self::assertInstanceOf(Fixtures\Cat::class, $pet);
+    }
+
+    public function testAutomapNull(): void
+    {
+        $array = $this->autoMapper->map(null, 'array');
+
+        self::assertNull($array);
+    }
+
+    public function testInvalidMappingBothArray(): void
+    {
+        self::expectException(NoMappingFoundException::class);
+
+        $data = ['test' => 'foo'];
+        $array = $this->autoMapper->map($data, 'array');
+    }
+
+    public function testNoAutoRegister(): void
+    {
+        self::expectException(NoMappingFoundException::class);
+
+        $automapper = AutoMapper::create(false, null, null, 'Mapper_', true, false);
+        $automapper->getMapper(Fixtures\User::class, Fixtures\UserDTO::class);
+    }
+
+    public function testWithMixedArray(): void
+    {
+        $user = new Fixtures\User(1, 'yolo', '13');
+        $user->setProperties(['foo' => 'bar']);
+
+        /** @var Fixtures\UserDTOProperties $dto */
+        $dto = $this->autoMapper->map($user, Fixtures\UserDTOProperties::class);
+
+        self::assertInstanceOf(Fixtures\UserDTOProperties::class, $dto);
+        self::assertSame(['foo' => 'bar'], $dto->getProperties());
+    }
+
+    public function testCustomTransformerFromArrayToObject(): void
+    {
+        $this->buildAutoMapper([new Fixtures\Transformer\MoneyTransformerFactory()]);
+
+        $data = [
+            'id' => 4582,
+            'price' => [
+                'amount' => 1000,
+                'currency' => 'EUR',
+            ],
+        ];
+        $order = $this->autoMapper->map($data, Fixtures\Order::class);
+
+        self::assertInstanceOf(Fixtures\Order::class, $order);
+        self::assertInstanceOf(\Money\Money::class, $order->price);
+        self::assertEquals(1000, $order->price->getAmount());
+        self::assertEquals('EUR', $order->price->getCurrency()->getCode());
+    }
+
+    public function testCustomTransformerFromObjectToArray(): void
+    {
+        $this->buildAutoMapper([new Fixtures\Transformer\MoneyTransformerFactory()]);
+
+        $order = new Fixtures\Order();
+        $order->id = 4582;
+        $order->price = new \Money\Money(1000, new \Money\Currency('EUR'));
+        $data = $this->autoMapper->map($order, 'array');
+
+        self::assertIsArray($data);
+        self::assertEquals(4582, $data['id']);
+        self::assertIsArray($data['price']);
+        self::assertEquals(1000, $data['price']['amount']);
+        self::assertEquals('EUR', $data['price']['currency']);
+    }
+
+    public function testCustomTransformerFromObjectToObject(): void
+    {
+        $this->buildAutoMapper([new Fixtures\Transformer\MoneyTransformerFactory()]);
+
+        $order = new Fixtures\Order();
+        $order->id = 4582;
+        $order->price = new \Money\Money(1000, new \Money\Currency('EUR'));
+        $newOrder = new Fixtures\Order();
+        $newOrder = $this->autoMapper->map($order, $newOrder);
+
+        self::assertInstanceOf(Fixtures\Order::class, $newOrder);
+        self::assertInstanceOf(\Money\Money::class, $newOrder->price);
+        self::assertEquals(1000, $newOrder->price->getAmount());
+        self::assertEquals('EUR', $newOrder->price->getCurrency()->getCode());
+    }
+
+    /**
+     * @requires PHP >= 7.4
+     */
+    public function testIssue425(): void
+    {
+        $data = [1, 2, 3, 4, 5];
+        $foo = new Fixtures\Issue425\Foo($data);
+        $bar = $this->autoMapper->map($foo, Fixtures\Issue425\Bar::class);
+
+        self::assertEquals($data, $bar->property);
+    }
+
+    public function testArrayWithKeys(): void
+    {
+        $arguments = ['foo', 'azerty' => 'bar', 'baz'];
+        $parameters = new Fixtures\Parameters($arguments);
+
+        $data = $this->autoMapper->map($parameters, 'array');
+        self::assertEquals($arguments, $data['parameters']);
+
+        // ----------------------------------------------------------------------------------------------------
+
+        $arguments = ['foo', 'bar', 'baz'];
+        $parameters = new Fixtures\Parameters($arguments);
+
+        $data = $this->autoMapper->map($parameters, 'array');
+        self::assertEquals($arguments, $data['parameters']);
+
+        // ----------------------------------------------------------------------------------------------------
+
+        $arguments = ['foo' => 'azerty', 'bar' => 'qwerty', 'baz' => 'dvorak'];
+        $parameters = new Fixtures\Parameters($arguments);
+
+        $data = $this->autoMapper->map($parameters, 'array');
+        self::assertEquals($arguments, $data['parameters']);
+    }
+
+    public function testArrayWithFailedKeys(): void
+    {
+        $arguments = ['foo', 'azerty' => 'bar', 'baz'];
+        $parameters = new Fixtures\WrongParameters($arguments);
+
+        $data = $this->autoMapper->map($parameters, 'array');
+        self::assertNotEquals($arguments, $data['parameters']);
+
+        // ----------------------------------------------------------------------------------------------------
+
+        $arguments = ['foo', 'bar', 'baz'];
+        $parameters = new Fixtures\WrongParameters($arguments);
+
+        $data = $this->autoMapper->map($parameters, 'array');
+        self::assertEquals($arguments, $data['parameters']);
+
+        // ----------------------------------------------------------------------------------------------------
+
+        $arguments = ['foo' => 'azerty', 'bar' => 'qwerty', 'baz' => 'dvorak'];
+        $parameters = new Fixtures\WrongParameters($arguments);
+
+        $data = $this->autoMapper->map($parameters, 'array');
+        self::assertNotEquals($arguments, $data['parameters']);
+    }
+
+    public function testSymfonyUlid(): void
+    {
+        // array -> object
+        $data = [
+            'ulid' => '01EXE87A54256F05N8P6SB2M9M',
+            'name' => 'Grégoire Pineau',
+        ];
+        /** @var Fixtures\SymfonyUlidUser $user */
+        $user = $this->autoMapper->map($data, Fixtures\SymfonyUlidUser::class);
+        self::assertInstanceOf(Ulid::class, $user->getUlid());
+        self::assertEquals('01EXE87A54256F05N8P6SB2M9M', $user->getUlid()->toBase32());
+        self::assertEquals('Grégoire Pineau', $user->name);
+
+        // object -> array
+        $user = new Fixtures\SymfonyUlidUser(new Ulid('01EXE89XR69GERC6GV3J4X38FJ'), 'Grégoire Pineau');
+        $data = $this->autoMapper->map($user, 'array');
+        self::assertEquals('01EXE89XR69GERC6GV3J4X38FJ', $data['ulid']);
+        self::assertEquals('Grégoire Pineau', $data['name']);
+
+        // object -> object
+        $user = new Fixtures\SymfonyUlidUser(new Ulid('01EXE8A6TNWVCEGMZ36AX8N9MC'), 'Grégoire Pineau');
+        /** @var Fixtures\SymfonyUlidUser $newUser */
+        $newUser = $this->autoMapper->map($user, Fixtures\SymfonyUlidUser::class);
+        self::assertInstanceOf(Ulid::class, $user->getUlid());
+        self::assertEquals('01EXE8A6TNWVCEGMZ36AX8N9MC', $newUser->getUlid()->toBase32());
+        self::assertEquals('Grégoire Pineau', $newUser->name);
+
+        // array -> object // uuid v1
+        $uuidV1 = Uuid::v1();
+        $data = [
+            'uuid' => $uuidV1->toRfc4122(),
+            'name' => 'Grégoire Pineau',
+        ];
+        /** @var Fixtures\SymfonyUuidUser $user */
+        $user = $this->autoMapper->map($data, Fixtures\SymfonyUuidUser::class);
+        self::assertInstanceOf(Uuid::class, $user->getUuid());
+        self::assertEquals($uuidV1->toRfc4122(), $user->getUuid()->toRfc4122());
+        self::assertEquals('Grégoire Pineau', $user->name);
+        // object -> array // uuid v3
+        $uuidV3 = Uuid::v3(Uuid::v4(), 'jolicode');
+        $user = new Fixtures\SymfonyUuidUser($uuidV3, 'Grégoire Pineau');
+        $data = $this->autoMapper->map($user, 'array');
+        self::assertEquals($uuidV3->toRfc4122(), $data['uuid']);
+        self::assertEquals('Grégoire Pineau', $data['name']);
+
+        // object -> object // uuid v4
+        $uuidV4 = Uuid::v4();
+        $user = new Fixtures\SymfonyUuidUser($uuidV4, 'Grégoire Pineau');
+        /** @var Fixtures\SymfonyUuidUser $newUser */
+        $newUser = $this->autoMapper->map($user, Fixtures\SymfonyUuidUser::class);
+        self::assertInstanceOf(Uuid::class, $user->getUuid());
+        self::assertEquals($uuidV4->toRfc4122(), $newUser->getUuid()->toRfc4122());
+        self::assertEquals('Grégoire Pineau', $newUser->name);
+    }
+
+    public function testSkipNullValues(): void
+    {
+        $entity = new Fixtures\SkipNullValues\Entity();
+        $entity->setName('foobar');
+        $input = new Fixtures\SkipNullValues\Input();
+
+        /** @var Fixtures\SkipNullValues\Entity $entity */
+        $entity = $this->autoMapper->map($input, $entity, ['skip_null_values' => true]);
+        self::assertEquals('foobar', $entity->getName());
+    }
+
+    public function testAdderAndRemoverWithClass()
+    {
+        $petOwner = [
+            'pets' => [
+                ['type' => 'cat', 'name' => 'Félix'],
+                ['type' => 'dog', 'name' => 'Coco'],
+            ],
+        ];
+
+        $petOwnerData = $this->autoMapper->map($petOwner, Fixtures\PetOwner::class);
+
+        self::assertIsArray($petOwnerData->getPets());
+        self::assertCount(2, $petOwnerData->getPets());
+        self::assertSame('Félix', $petOwnerData->getPets()[0]->name);
+        self::assertSame('cat', $petOwnerData->getPets()[0]->type);
+        self::assertSame('Coco', $petOwnerData->getPets()[1]->name);
+        self::assertSame('dog', $petOwnerData->getPets()[1]->type);
+    }
+
+    public function testAdderAndRemoverWithInstance()
+    {
+        $fish = new Fixtures\Fish();
+        $fish->name = 'Nemo';
+        $fish->type = 'fish';
+
+        $petOwner = new Fixtures\PetOwner();
+        $petOwner->addPet($fish);
+
+        $petOwnerAsArray = [
+            'pets' => [
+                ['type' => 'cat', 'name' => 'Félix'],
+                ['type' => 'dog', 'name' => 'Coco'],
+            ],
+        ];
+
+        $this->autoMapper->map($petOwnerAsArray, $petOwner);
+
+        self::assertIsArray($petOwner->getPets());
+        self::assertCount(3, $petOwner->getPets());
+        self::assertSame('Nemo', $petOwner->getPets()[0]->name);
+        self::assertSame('fish', $petOwner->getPets()[0]->type);
+        self::assertSame('Félix', $petOwner->getPets()[1]->name);
+        self::assertSame('cat', $petOwner->getPets()[1]->type);
+        self::assertSame('Coco', $petOwner->getPets()[2]->name);
+        self::assertSame('dog', $petOwner->getPets()[2]->type);
+    }
+
+    public function testAdderAndRemoverWithNull()
+    {
+        $petOwner = [
+            'pets' => [
+                null,
+                null,
+            ],
+        ];
+
+        $petOwnerData = $this->autoMapper->map($petOwner, Fixtures\PetOwner::class);
+
+        self::assertIsArray($petOwnerData->getPets());
+        self::assertCount(0, $petOwnerData->getPets());
+    }
+
+    public function testIssueTargetToPopulate()
+    {
+        $source = new Fixtures\IssueTargetToPopulate\VatModel();
+        $source->setCountryCode('fr');
+        $source->setStandardVatRate(21.0);
+        $source->setReducedVatRate(5.5);
+        $source->setDisplayIncVatPrices(true);
+
+        $target = new Fixtures\IssueTargetToPopulate\VatEntity('en');
+        $target->setId(1);
+
+        /** @var Fixtures\IssueTargetToPopulate\VatEntity $target */
+        $target = $this->autoMapper->map($source, $target);
+
+        self::assertEquals(1, $target->getId());
+        self::assertEquals('fr', $target->getCountryCode());
+        self::assertEquals(21.0, $target->getStandardVatRate());
+        self::assertEquals(5.5, $target->getReducedVatRate());
+        self::assertTrue($target->isDisplayIncVatPrices());
+    }
+
+    public function testPartialConstructorWithTargetToPopulate(): void
+    {
+        $source = new Fixtures\User(1, 'Jack', 37);
+        /** @var Fixtures\UserPartialConstructor $target */
+        $target = $this->autoMapper->map($source, Fixtures\UserPartialConstructor::class);
+
+        self::assertEquals(1, $target->getId());
+        self::assertEquals('Jack', $target->name);
+        self::assertEquals(37, $target->age);
+    }
+
+    public function testEnum(): void
+    {
+        // enum source
+        $address = new Fixtures\AddressWithEnum();
+        $address->setType(Fixtures\AddressType::APARTMENT);
+        /** @var array $addressData */
+        $addressData = $this->autoMapper->map($address, 'array');
+        $var = Fixtures\AddressType::APARTMENT; // only here for lower PHP version handling
+        self::assertEquals($var->value, $addressData['type']);
+
+        // enum target
+        $data = ['type' => 'flat'];
+        /** @var Fixtures\AddressWithEnum $address */
+        $address = $this->autoMapper->map($data, Fixtures\AddressWithEnum::class);
+        self::assertEquals(Fixtures\AddressType::FLAT, $address->getType());
+
+        // both source & target are enums
+        $address = new Fixtures\AddressWithEnum();
+        $address->setType(Fixtures\AddressType::FLAT);
+        /** @var Fixtures\AddressWithEnum $copyAddress */
+        $copyAddress = $this->autoMapper->map($address, Fixtures\AddressWithEnum::class);
+        self::assertEquals($address->getType(), $copyAddress->getType());
+    }
+
+    /**
+     * @dataProvider provideReadonly
+     */
+    public function testReadonly(string $addressWithReadonlyClass): void
+    {
+        $this->buildAutoMapper([], true);
+
+        $address = new Fixtures\Address();
+        $address->setCity('city');
+
+        self::assertSame(
+            ['city' => 'city'],
+            $this->autoMapper->map(new $addressWithReadonlyClass('city'), 'array')
+        );
+
+        self::assertEquals(
+            $address,
+            $this->autoMapper->map(new $addressWithReadonlyClass('city'), Fixtures\Address::class)
+        );
+
+        self::assertEquals(
+            new $addressWithReadonlyClass('city'),
+            $this->autoMapper->map(['city' => 'city'], $addressWithReadonlyClass)
+        );
+
+        self::assertEquals(
+            new $addressWithReadonlyClass('city'),
+            $this->autoMapper->map($address, $addressWithReadonlyClass)
+        );
+
+        // assert that readonly property / class as a target object does not break automapping
+        $address->setCity('another city');
+        self::assertEquals(
+            new $addressWithReadonlyClass('city'),
+            $this->autoMapper->map($address, new $addressWithReadonlyClass('city'))
+        );
+    }
+
+    public static function provideReadonly(): iterable
+    {
+        yield [Fixtures\AddressDTOWithReadonly::class];
+        yield [Fixtures\AddressDTOWithReadonlyPromotedProperty::class];
+
+        if (\PHP_VERSION_ID >= 80200) {
+            yield [Fixtures\AddressDTOReadonlyClass::class];
+        }
+    }
+
+    public function testIgnoreInSource(): void
+    {
+        $foo = new Fixtures\FooIgnore();
+        $foo->id = 5;
+        $fooArray = $this->autoMapper->map($foo, 'array');
+
+        self::assertSame([], $fooArray);
+    }
+
+    public function testIgnoreInTarget(): void
+    {
+        $foo = new Fixtures\Foo();
+        $fooIgnore = $this->autoMapper->map($foo, Fixtures\FooIgnore::class);
+
+        self::assertNull($fooIgnore->id);
+    }
+
+    /**
+     * @requires PHP 8.2
+     */
+    public function testTargetReadonlyClass(): void
+    {
+        $data = ['city' => 'Nantes'];
+        $toPopulate = new Fixtures\AddressDtoSecondReadonlyClass('city', '67100');
+
+        self::expectException(ReadOnlyTargetException::class);
+        $this->autoMapper->map($data, $toPopulate);
+    }
+
+    /**
+     * @requires PHP 8.2
+     */
+    public function testTargetReadonlyClassSkippedContext(): void
+    {
+        $data = ['city' => 'Nantes'];
+        $toPopulate = new Fixtures\AddressDtoSecondReadonlyClass('city', '67100');
+
+        $this->autoMapper->map($data, $toPopulate, [MapperContext::ALLOW_READONLY_TARGET_TO_POPULATE => true]);
+
+        // value didn't changed because the object class is readonly, we can't change the value there
+        self::assertEquals('city', $toPopulate->city);
+    }
+
+    /**
+     * @requires PHP 8.2
+     */
+    public function testTargetReadonlyClassAllowed(): void
+    {
+        $this->buildAutoMapper([], true);
+
+        $data = ['city' => 'Nantes'];
+        $toPopulate = new Fixtures\AddressDTOReadonlyClass('city');
+
+        $this->autoMapper->map($data, $toPopulate);
+
+        // value didn't changed because the object class is readonly, we can't change the value there
+        self::assertEquals('city', $toPopulate->city);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Extractor/FromSourceMappingExtractorTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Extractor/FromSourceMappingExtractorTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Extractor;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Symfony\Component\AutoMapper\Exception\InvalidMappingException;
+use Symfony\Component\AutoMapper\Extractor\FromSourceMappingExtractor;
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\MapperMetadata;
+use Symfony\Component\AutoMapper\Tests\Fixtures;
+use Symfony\Component\AutoMapper\Transformer\ArrayTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\BuiltinTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\ChainTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\DateTimeTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\MultipleTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\NullableTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\ObjectTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\UniqueTypeTransformerFactory;
+use Symfony\Component\AutoMapper\Tests\AutoMapperBase;
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class FromSourceMappingExtractorTest extends AutoMapperBase
+{
+    protected FromSourceMappingExtractor $fromSourceMappingExtractor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->fromSourceMappingExtractorBootstrap();
+    }
+
+    private function fromSourceMappingExtractorBootstrap(bool $private = true): void
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $flags = ReflectionExtractor::ALLOW_PUBLIC;
+
+        if ($private) {
+            $flags |= ReflectionExtractor::ALLOW_PROTECTED | ReflectionExtractor::ALLOW_PRIVATE;
+        }
+
+        $reflectionExtractor = new ReflectionExtractor(null, null, null, true, $flags);
+        $transformerFactory = new ChainTransformerFactory();
+
+        $phpStanExtractor = new PhpStanExtractor();
+        $propertyInfoExtractor = new PropertyInfoExtractor(
+            [$reflectionExtractor],
+            [$phpStanExtractor, $reflectionExtractor],
+            [$reflectionExtractor],
+            [$reflectionExtractor]
+        );
+
+        $this->fromSourceMappingExtractor = new FromSourceMappingExtractor(
+            $propertyInfoExtractor,
+            $reflectionExtractor,
+            $reflectionExtractor,
+            $transformerFactory,
+            $classMetadataFactory
+        );
+
+        $transformerFactory->addTransformerFactory(new MultipleTransformerFactory($transformerFactory));
+        $transformerFactory->addTransformerFactory(new NullableTransformerFactory($transformerFactory));
+        $transformerFactory->addTransformerFactory(new UniqueTypeTransformerFactory($transformerFactory));
+        $transformerFactory->addTransformerFactory(new DateTimeTransformerFactory());
+        $transformerFactory->addTransformerFactory(new BuiltinTransformerFactory());
+        $transformerFactory->addTransformerFactory(new ArrayTransformerFactory($transformerFactory));
+        $transformerFactory->addTransformerFactory(new ObjectTransformerFactory($this->autoMapper));
+    }
+
+    public function testWithTargetAsArray(): void
+    {
+        $userReflection = new \ReflectionClass(Fixtures\User::class);
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, Fixtures\User::class, 'array', false);
+        $sourcePropertiesMapping = $this->fromSourceMappingExtractor->getPropertiesMapping($mapperMetadata);
+
+        self::assertCount(\count($userReflection->getProperties()), $sourcePropertiesMapping);
+        /** @var PropertyMapping $propertyMapping */
+        foreach ($sourcePropertiesMapping as $propertyMapping) {
+            self::assertTrue($userReflection->hasProperty($propertyMapping->property));
+        }
+    }
+
+    public function testWithTargetAsStdClass(): void
+    {
+        $userReflection = new \ReflectionClass(Fixtures\User::class);
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, Fixtures\User::class, 'stdClass', false);
+        $sourcePropertiesMapping = $this->fromSourceMappingExtractor->getPropertiesMapping($mapperMetadata);
+
+        self::assertCount(\count($userReflection->getProperties()), $sourcePropertiesMapping);
+        /** @var PropertyMapping $propertyMapping */
+        foreach ($sourcePropertiesMapping as $propertyMapping) {
+            self::assertTrue($userReflection->hasProperty($propertyMapping->property));
+        }
+    }
+
+    public function testWithSourceAsEmpty(): void
+    {
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, Fixtures\Empty_::class, 'array', false);
+        $sourcePropertiesMapping = $this->fromSourceMappingExtractor->getPropertiesMapping($mapperMetadata);
+
+        self::assertCount(0, $sourcePropertiesMapping);
+    }
+
+    public function testWithSourceAsPrivate(): void
+    {
+        $privateReflection = new \ReflectionClass(Fixtures\Private_::class);
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, Fixtures\Private_::class, 'array', false);
+        $sourcePropertiesMapping = $this->fromSourceMappingExtractor->getPropertiesMapping($mapperMetadata);
+        self::assertCount(\count($privateReflection->getProperties()), $sourcePropertiesMapping);
+
+        $this->fromSourceMappingExtractorBootstrap(false);
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, Fixtures\Private_::class, 'array', false);
+        $sourcePropertiesMapping = $this->fromSourceMappingExtractor->getPropertiesMapping($mapperMetadata);
+        self::assertCount(0, $sourcePropertiesMapping);
+    }
+
+    public function testWithSourceAsArray(): void
+    {
+        self::expectException(InvalidMappingException::class);
+        self::expectExceptionMessage('Only array or stdClass are accepted as a target');
+
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, 'array', Fixtures\User::class, false);
+        $this->fromSourceMappingExtractor->getPropertiesMapping($mapperMetadata);
+    }
+
+    public function testWithSourceAsStdClass(): void
+    {
+        self::expectException(InvalidMappingException::class);
+        self::expectExceptionMessage('Only array or stdClass are accepted as a target');
+
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, 'stdClass', Fixtures\User::class, false);
+        $this->fromSourceMappingExtractor->getPropertiesMapping($mapperMetadata);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Extractor/FromTargetMappingExtractorTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Extractor/FromTargetMappingExtractorTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Extractor;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Symfony\Component\AutoMapper\Exception\InvalidMappingException;
+use Symfony\Component\AutoMapper\Extractor\FromTargetMappingExtractor;
+use Symfony\Component\AutoMapper\MapperMetadata;
+use Symfony\Component\AutoMapper\Tests\Fixtures;
+use Symfony\Component\AutoMapper\Transformer\ArrayTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\BuiltinTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\ChainTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\DateTimeTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\MultipleTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\NullableTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\ObjectTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\UniqueTypeTransformerFactory;
+use Symfony\Component\AutoMapper\Tests\AutoMapperBase;
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class FromTargetMappingExtractorTest extends AutoMapperBase
+{
+    protected FromTargetMappingExtractor $fromTargetMappingExtractor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->fromTargetMappingExtractorBootstrap();
+    }
+
+    private function fromTargetMappingExtractorBootstrap(bool $private = true): void
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $flags = ReflectionExtractor::ALLOW_PUBLIC;
+
+        if ($private) {
+            $flags |= ReflectionExtractor::ALLOW_PROTECTED | ReflectionExtractor::ALLOW_PRIVATE;
+        }
+
+        $reflectionExtractor = new ReflectionExtractor(null, null, null, true, $flags);
+
+        $phpStanExtractor = new PhpStanExtractor();
+        $propertyInfoExtractor = new PropertyInfoExtractor(
+            [$reflectionExtractor],
+            [$phpStanExtractor, $reflectionExtractor],
+            [$reflectionExtractor],
+            [$reflectionExtractor]
+        );
+
+        $transformerFactory = new ChainTransformerFactory();
+
+        $this->fromTargetMappingExtractor = new FromTargetMappingExtractor(
+            $propertyInfoExtractor,
+            $reflectionExtractor,
+            $reflectionExtractor,
+            $transformerFactory,
+            $classMetadataFactory
+        );
+
+        $transformerFactory->addTransformerFactory(new MultipleTransformerFactory($transformerFactory));
+        $transformerFactory->addTransformerFactory(new NullableTransformerFactory($transformerFactory));
+        $transformerFactory->addTransformerFactory(new UniqueTypeTransformerFactory($transformerFactory));
+        $transformerFactory->addTransformerFactory(new DateTimeTransformerFactory());
+        $transformerFactory->addTransformerFactory(new BuiltinTransformerFactory());
+        $transformerFactory->addTransformerFactory(new ArrayTransformerFactory($transformerFactory));
+        $transformerFactory->addTransformerFactory(new ObjectTransformerFactory($this->autoMapper));
+    }
+
+    public function testWithSourceAsArray(): void
+    {
+        $userReflection = new \ReflectionClass(Fixtures\User::class);
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, 'array', Fixtures\User::class, false);
+        $targetPropertiesMapping = $this->fromTargetMappingExtractor->getPropertiesMapping($mapperMetadata);
+
+        self::assertCount(\count($userReflection->getProperties()), $targetPropertiesMapping);
+        foreach ($targetPropertiesMapping as $propertyMapping) {
+            self::assertTrue($userReflection->hasProperty($propertyMapping->property));
+        }
+    }
+
+    public function testWithSourceAsStdClass(): void
+    {
+        $userReflection = new \ReflectionClass(Fixtures\User::class);
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, 'stdClass', Fixtures\User::class, false);
+        $targetPropertiesMapping = $this->fromTargetMappingExtractor->getPropertiesMapping($mapperMetadata);
+
+        self::assertCount(\count($userReflection->getProperties()), $targetPropertiesMapping);
+        foreach ($targetPropertiesMapping as $propertyMapping) {
+            self::assertTrue($userReflection->hasProperty($propertyMapping->property));
+        }
+    }
+
+    public function testWithTargetAsEmpty(): void
+    {
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, 'array', Fixtures\Empty_::class, false);
+        $targetPropertiesMapping = $this->fromTargetMappingExtractor->getPropertiesMapping($mapperMetadata);
+
+        self::assertCount(0, $targetPropertiesMapping);
+    }
+
+    public function testWithTargetAsPrivate(): void
+    {
+        $privateReflection = new \ReflectionClass(Fixtures\Private_::class);
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, 'array', Fixtures\Private_::class, false);
+        $targetPropertiesMapping = $this->fromTargetMappingExtractor->getPropertiesMapping($mapperMetadata);
+        self::assertCount(\count($privateReflection->getProperties()), $targetPropertiesMapping);
+
+        $this->fromTargetMappingExtractorBootstrap(false);
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, 'array', Fixtures\Private_::class, false);
+        $targetPropertiesMapping = $this->fromTargetMappingExtractor->getPropertiesMapping($mapperMetadata);
+        self::assertCount(0, $targetPropertiesMapping);
+    }
+
+    public function testWithTargetAsArray(): void
+    {
+        self::expectException(InvalidMappingException::class);
+        self::expectExceptionMessage('Only array or stdClass are accepted as a source');
+
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, Fixtures\User::class, 'array', false);
+        $this->fromTargetMappingExtractor->getPropertiesMapping($mapperMetadata);
+    }
+
+    public function testWithTargetAsStdClass(): void
+    {
+        self::expectException(InvalidMappingException::class);
+        self::expectExceptionMessage('Only array or stdClass are accepted as a source');
+
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, Fixtures\User::class, 'stdClass', false);
+        $this->fromTargetMappingExtractor->getPropertiesMapping($mapperMetadata);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/Address.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/Address.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class Address
+{
+    /**
+     * @var string|null
+     */
+    private $city;
+
+    /**
+     * @param string $city
+     */
+    public function setCity(?string $city): void
+    {
+        $this->city = $city;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressBar.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressBar.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class AddressBar
+{
+    /**
+     * @var string|null
+     */
+    public $city;
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressDTO.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressDTO.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class AddressDTO
+{
+    /**
+     * @var string|null
+     */
+    public $city;
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressDTOReadonlyClass.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressDTOReadonlyClass.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+readonly class AddressDTOReadonlyClass
+{
+    public function __construct(public string $city)
+    {
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressDTOWithReadonly.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressDTOWithReadonly.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+final class AddressDTOWithReadonly
+{
+    private readonly string $city;
+
+    public function __construct(string $city)
+    {
+        $this->city = $city;
+    }
+
+    public function getCity(): string
+    {
+        return $this->city;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressDTOWithReadonlyPromotedProperty.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressDTOWithReadonlyPromotedProperty.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+final class AddressDTOWithReadonlyPromotedProperty
+{
+    public function __construct(public readonly string $city)
+    {
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressDtoSecondReadonlyClass.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressDtoSecondReadonlyClass.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+readonly class AddressDtoSecondReadonlyClass
+{
+    public function __construct(public string $city, public string $postalCode)
+    {
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressFoo.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressFoo.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class AddressFoo
+{
+    /**
+     * @var CityFoo
+     */
+    public $city;
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressNoTypes.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressNoTypes.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class AddressNoTypes
+{
+    public $city;
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressNotWritable.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressNotWritable.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class AddressNotWritable
+{
+    /**
+     * @var string|null
+     */
+    private $city;
+
+    public function getCity(): ?string
+    {
+        return $this->city;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressType.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+enum AddressType: string
+{
+    case FLAT = 'flat';
+    case APARTMENT = 'apartment';
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressWithEnum.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/AddressWithEnum.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class AddressWithEnum
+{
+    private AddressType $type;
+
+    public function setType(AddressType $type): void
+    {
+        $this->type = $type;
+    }
+
+    public function getType(): AddressType
+    {
+        return $this->type;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/Bar.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/Bar.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Annotation\Groups;
+
+class Bar
+{
+    /**
+     * @var int|null
+     */
+    #[Groups(['group2', 'group3'])]
+    private $id;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): void
+    {
+        $this->id = $id;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/Cat.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/Cat.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class Cat extends Pet
+{
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/CircularBar.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/CircularBar.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class CircularBar
+{
+    /** @var CircularBaz */
+    public $baz;
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/CircularBaz.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/CircularBaz.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class CircularBaz
+{
+    /** @var CircularFoo */
+    public $foo;
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/CircularFoo.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/CircularFoo.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class CircularFoo
+{
+    /** @var CircularBar */
+    public $bar;
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/CityFoo.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/CityFoo.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class CityFoo
+{
+    public $name;
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/Dog.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/Dog.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class Dog extends Pet
+{
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/Empty_.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/Empty_.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class Empty_
+{
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/Fish.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/Fish.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class Fish extends Pet
+{
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/Foo.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/Foo.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Annotation\Groups;
+
+class Foo
+{
+    #[Groups(['group1', 'group2', 'group3'])]
+    private int $id = 0;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/FooIgnore.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/FooIgnore.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Annotation\Ignore;
+
+class FooIgnore
+{
+    #[Ignore]
+    public ?int $id = null;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/FooMaxDepth.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/FooMaxDepth.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Annotation\MaxDepth;
+
+class FooMaxDepth
+{
+    /**
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @var FooMaxDepth|null
+     */
+    #[MaxDepth(2)]
+    private $child;
+
+    public function __construct(int $id, ?self $child = null)
+    {
+        $this->id = $id;
+        $this->child = $child;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getChild(): ?self
+    {
+        return $this->child;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/FooNoProperties.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/FooNoProperties.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class FooNoProperties
+{
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/Issue425/Bar.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/Issue425/Bar.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures\Issue425;
+
+class Bar
+{
+    public array $property = [];
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/Issue425/Foo.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/Issue425/Foo.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures\Issue425;
+
+use Symfony\Component\AutoMapper\Tests\Fixtures\Issue425\bigint;
+
+class Foo
+{
+    /** @var bigint[] */
+    private array $property = [];
+
+    public function __construct(array $property)
+    {
+        $this->property = $property;
+    }
+
+    public function getProperty(): array
+    {
+        return $this->property;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/IssueTargetToPopulate/VatEntity.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/IssueTargetToPopulate/VatEntity.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures\IssueTargetToPopulate;
+
+class VatEntity
+{
+    /**
+     * @var int|null
+     */
+    private $id = null;
+
+    /**
+     * @var string
+     */
+    private $countryCode;
+
+    /**
+     * @var string|null
+     */
+    private $stateCode;
+
+    /**
+     * @var float
+     */
+    private $standardVatRate;
+
+    /**
+     * @var float
+     */
+    private $reducedVatRate;
+
+    /**
+     * @var bool
+     */
+    private $displayIncVatPrices;
+
+    public function __construct(
+        string $countryCode,
+        string $stateCode = null,
+        float $standardVatRate = 0,
+        float $reducedVatRate = 0,
+        bool $displayIncVatPrices = false
+    ) {
+        $this->countryCode = $countryCode;
+        $this->stateCode = $stateCode;
+        $this->standardVatRate = $standardVatRate;
+        $this->reducedVatRate = $reducedVatRate;
+        $this->displayIncVatPrices = $displayIncVatPrices;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getCountryCode(): string
+    {
+        return $this->countryCode;
+    }
+
+    public function setCountryCode(string $countryCode): void
+    {
+        $this->countryCode = $countryCode;
+    }
+
+    public function getStateCode(): ?string
+    {
+        return $this->stateCode;
+    }
+
+    public function setStateCode(?string $stateCode): void
+    {
+        $this->stateCode = $stateCode;
+    }
+
+    public function getStandardVatRate(): float
+    {
+        return $this->standardVatRate;
+    }
+
+    public function setStandardVatRate(float $standardVatRate): void
+    {
+        $this->standardVatRate = $standardVatRate;
+    }
+
+    public function getReducedVatRate(): float
+    {
+        return $this->reducedVatRate;
+    }
+
+    public function setReducedVatRate(float $reducedVatRate): void
+    {
+        $this->reducedVatRate = $reducedVatRate;
+    }
+
+    public function isDisplayIncVatPrices(): bool
+    {
+        return $this->displayIncVatPrices;
+    }
+
+    public function setDisplayIncVatPrices(bool $displayIncVatPrices): void
+    {
+        $this->displayIncVatPrices = $displayIncVatPrices;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/IssueTargetToPopulate/VatModel.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/IssueTargetToPopulate/VatModel.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures\IssueTargetToPopulate;
+
+class VatModel
+{
+    /**
+     * @var string
+     */
+    protected $countryCode;
+    /**
+     * @var string|null
+     */
+    protected $stateCode;
+    /**
+     * @var float
+     */
+    protected $standardVatRate;
+    /**
+     * @var float
+     */
+    protected $reducedVatRate;
+    /**
+     * @var bool
+     */
+    protected $displayIncVatPrices = false;
+
+    public function getCountryCode(): string
+    {
+        return $this->countryCode;
+    }
+
+    public function setCountryCode(string $countryCode): self
+    {
+        $this->countryCode = $countryCode;
+
+        return $this;
+    }
+
+    public function getStateCode(): ?string
+    {
+        return $this->stateCode;
+    }
+
+    public function setStateCode(?string $stateCode): self
+    {
+        $this->stateCode = $stateCode;
+
+        return $this;
+    }
+
+    public function getStandardVatRate(): float
+    {
+        return $this->standardVatRate;
+    }
+
+    public function setStandardVatRate(float $standardVatRate): self
+    {
+        $this->standardVatRate = $standardVatRate;
+
+        return $this;
+    }
+
+    public function getReducedVatRate(): float
+    {
+        return $this->reducedVatRate;
+    }
+
+    public function setReducedVatRate(float $reducedVatRate): self
+    {
+        $this->reducedVatRate = $reducedVatRate;
+
+        return $this;
+    }
+
+    public function getDisplayIncVatPrices(): bool
+    {
+        return $this->displayIncVatPrices;
+    }
+
+    public function setDisplayIncVatPrices(bool $displayIncVatPrices): self
+    {
+        $this->displayIncVatPrices = $displayIncVatPrices;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/Node.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/Node.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class Node
+{
+    /**
+     * @var Node
+     */
+    public $parent;
+
+    /**
+     * @var Node[]
+     */
+    public $childs = [];
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/Order.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/Order.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+use Money\Money;
+
+class Order
+{
+    /** @var int */
+    public $id;
+
+    /** @var Money */
+    public $price;
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/Parameters.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/Parameters.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class Parameters
+{
+    /** @var array<string, string> */
+    private $parameters;
+
+    /**
+     * @param array<string, string> $parameters
+     */
+    public function __construct(array $parameters)
+    {
+        $this->setParameters($parameters);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * @param array<string, string> $parameters
+     */
+    public function setParameters(array $parameters): void
+    {
+        $this->parameters = $parameters;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/Pet.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/Pet.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
+
+#[DiscriminatorMap(typeProperty: 'type', mapping: [
+    'cat' => Cat::class,
+    'dog' => Dog::class,
+    'fish' => Fish::class,
+])]
+abstract class Pet
+{
+    /** @var string */
+    public $type;
+
+    /** @var string */
+    public $name;
+
+    /** @var PetOwner */
+    public $owner;
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/PetOwner.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/PetOwner.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class PetOwner
+{
+    /** @var array<int, Pet> */
+    private $pets;
+
+    public function __construct()
+    {
+        $this->pets = [];
+    }
+
+    /**
+     * @return Pet[]
+     */
+    public function getPets(): array
+    {
+        return $this->pets;
+    }
+
+    public function addPet(Pet $pet): void
+    {
+        $this->pets[] = $pet;
+    }
+
+    public function removePet(Pet $pet): void
+    {
+        $index = array_search($pet, $this->pets);
+
+        if ($index !== false) {
+            unset($this->pets[$index]);
+        }
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/PrivateUser.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/PrivateUser.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class PrivateUser
+{
+    /** @var int */
+    private $id;
+
+    /** @var string */
+    private $firstName;
+
+    /** @var string */
+    private $lastName;
+
+    public function __construct(int $id, string $firstName, string $lastName)
+    {
+        $this->id = $id;
+        $this->firstName = $firstName;
+        $this->lastName = $lastName;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/PrivateUserDTO.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/PrivateUserDTO.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class PrivateUserDTO
+{
+    /** @var int */
+    private $id;
+
+    /** @var string */
+    private $firstName;
+
+    /** @var string */
+    private $lastName;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getFirstName(): string
+    {
+        return $this->firstName;
+    }
+
+    public function getLastName(): string
+    {
+        return $this->lastName;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/Private_.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/Private_.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class Private_
+{
+    /**
+     * @var int
+     */
+    private $id;
+
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/ReflectionExtractorTestFixture.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/ReflectionExtractorTestFixture.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class ReflectionExtractorTestFixture
+{
+    public function __construct($propertyConstruct)
+    {
+    }
+
+    public function getFoo(): string
+    {
+        return 'string';
+    }
+
+    public function setFoo(string $foo)
+    {
+    }
+
+    public function bar(?string $bar): string
+    {
+        return 'string';
+    }
+
+    public function isBaz(): bool
+    {
+        return true;
+    }
+
+    public function hasFoz(): bool
+    {
+        return false;
+    }
+
+    public function __get($name)
+    {
+    }
+
+    public function __set($name, $value)
+    {
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/SkipNullValues/Entity.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/SkipNullValues/Entity.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures\SkipNullValues;
+
+class Entity
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/SkipNullValues/Input.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/SkipNullValues/Input.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures\SkipNullValues;
+
+class Input
+{
+    /**
+     * @var string|null
+     */
+    public $name = null;
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/SymfonyUlidUser.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/SymfonyUlidUser.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+use Symfony\Component\Uid\Ulid;
+
+class SymfonyUlidUser
+{
+    /**
+     * @var Ulid
+     */
+    private $ulid;
+
+    /**
+     * @var string
+     */
+    public $name;
+
+    public function __construct(Ulid $ulid, string $name)
+    {
+        $this->ulid = $ulid;
+        $this->name = $name;
+    }
+
+    public function getUlid(): Ulid
+    {
+        return $this->ulid;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/SymfonyUuidUser.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/SymfonyUuidUser.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+use Symfony\Component\Uid\Uuid;
+
+class SymfonyUuidUser
+{
+    /**
+     * @var Uuid
+     */
+    private $uuid;
+
+    /**
+     * @var string
+     */
+    public $name;
+
+    public function __construct(Uuid $uuid, string $name)
+    {
+        $this->uuid = $uuid;
+        $this->name = $name;
+    }
+
+    public function getUuid(): Uuid
+    {
+        return $this->uuid;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/Transformer/ArrayToMoneyTransformer.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/Transformer/ArrayToMoneyTransformer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures\Transformer;
+
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\Generator\UniqueVariableScope;
+use Symfony\Component\AutoMapper\Transformer\TransformerInterface;
+use Money\Currency;
+use Money\Money;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+
+/**
+ * Transform an array to Money\Money object.
+ *
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class ArrayToMoneyTransformer implements TransformerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        return [new Expr\New_(new Name\FullyQualified(Money::class), [
+            new Arg(new Expr\ArrayDimFetch($input, new String_('amount'))),
+            new Arg(new Expr\New_(new Name\FullyQualified(Currency::class), [
+                new Arg(new Expr\ArrayDimFetch($input, new String_('currency'))),
+            ])),
+        ]), []];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDependencies(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function assignByRef(): bool
+    {
+        return false;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/Transformer/MoneyToArrayTransformer.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/Transformer/MoneyToArrayTransformer.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures\Transformer;
+
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\Generator\UniqueVariableScope;
+use Symfony\Component\AutoMapper\Transformer\TransformerInterface;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Expression;
+
+/**
+ * Transform a Money\Money object to an array.
+ *
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class MoneyToArrayTransformer implements TransformerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        $moneyVar = new Expr\Variable($uniqueVariableScope->getUniqueName('money'));
+
+        return [$moneyVar, [
+            new Expression(new Expr\Assign(new Expr\ArrayDimFetch($moneyVar, new String_('amount')), new Expr\MethodCall($input, 'getAmount'))),
+            new Expression(new Expr\Assign(new Expr\ArrayDimFetch($moneyVar, new String_('currency')), new Expr\MethodCall(new Expr\MethodCall($input, 'getCurrency'), 'getCode'))),
+        ]];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDependencies(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function assignByRef(): bool
+    {
+        return false;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/Transformer/MoneyToMoneyTransformer.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/Transformer/MoneyToMoneyTransformer.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures\Transformer;
+
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\Generator\UniqueVariableScope;
+use Symfony\Component\AutoMapper\Transformer\TransformerInterface;
+use Money\Currency;
+use Money\Money;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+
+/**
+ * Transform a Money\Money object to a new Money\Money object.
+ *
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class MoneyToMoneyTransformer implements TransformerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        return [
+            new Expr\New_(new Name\FullyQualified(Money::class), [
+                new Arg(new Expr\MethodCall($input, 'getAmount')),
+                new Arg(new Expr\New_(new Name\FullyQualified(Currency::class), [
+                    new Arg(new Expr\MethodCall(new Expr\MethodCall($input, 'getCurrency'), 'getCode')),
+                ])),
+            ]),
+            [],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDependencies(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function assignByRef(): bool
+    {
+        return false;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/Transformer/MoneyTransformerFactory.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/Transformer/MoneyTransformerFactory.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures\Transformer;
+
+use Symfony\Component\AutoMapper\MapperMetadataInterface;
+use Symfony\Component\AutoMapper\Transformer\AbstractUniqueTypeTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\TransformerInterface;
+use Money\Money;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class MoneyTransformerFactory extends AbstractUniqueTypeTransformerFactory
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function createTransformer(Type $sourceType, Type $targetType, MapperMetadataInterface $mapperMetadata): ?TransformerInterface
+    {
+        $isSourceMoney = $this->isMoneyType($sourceType);
+        $isTargetMoney = $this->isMoneyType($targetType);
+
+        if ($isSourceMoney && $isTargetMoney) {
+            return $this->createTransformerForSourceAndTarget();
+        }
+
+        if ($isSourceMoney && !$isTargetMoney) {
+            return $this->createTransformerForSource($targetType);
+        }
+
+        if ($isTargetMoney && !$isSourceMoney) {
+            return $this->createTransformerForTarget($sourceType);
+        }
+
+        return null;
+    }
+
+    protected function createTransformerForSource(Type $targetType): ?TransformerInterface
+    {
+        if (Type::BUILTIN_TYPE_ARRAY === $targetType->getBuiltinType()) {
+            return new MoneyToArrayTransformer();
+        }
+
+        return null;
+    }
+
+    protected function createTransformerForTarget(Type $sourceType): ?TransformerInterface
+    {
+        if (Type::BUILTIN_TYPE_ARRAY === $sourceType->getBuiltinType()) {
+            return new ArrayToMoneyTransformer();
+        }
+
+        return null;
+    }
+
+    protected function createTransformerForSourceAndTarget(): TransformerInterface
+    {
+        return new MoneyToMoneyTransformer();
+    }
+
+    private function isMoneyType(Type $type): bool
+    {
+        if (Type::BUILTIN_TYPE_OBJECT !== $type->getBuiltinType()) {
+            return false;
+        }
+
+        if (Money::class !== $type->getClassName() && !is_subclass_of($type->getClassName(), Money::class)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/UnitAddressType.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/UnitAddressType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+enum UnitAddressType
+{
+    case FLAT;
+    case APARTMENT;
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/User.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/User.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class User
+{
+    /**
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    public $name;
+
+    /**
+     * @var string|int
+     */
+    public $age;
+
+    /**
+     * @var string
+     */
+    private $email;
+
+    /**
+     * @var Address
+     */
+    public $address;
+
+    /**
+     * @var Address[]
+     */
+    public $addresses = [];
+
+    /**
+     * @var \DateTime
+     */
+    public $createdAt;
+
+    /**
+     * @var float
+     */
+    public $money;
+
+    /**
+     * @var iterable
+     */
+    public $languages;
+
+    /**
+     * @var mixed[]
+     */
+    protected $properties = [];
+
+    public function __construct($id, $name, $age)
+    {
+        $this->id = $id;
+        $this->name = $name;
+        $this->age = $age;
+        $this->email = 'test';
+        $this->createdAt = new \DateTime();
+        $this->money = 20.10;
+        $this->languages = new \ArrayObject();
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getProperties(): iterable
+    {
+        return $this->properties;
+    }
+
+    public function setProperties(iterable $properties): void
+    {
+        $this->properties = $properties;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/UserConstructorDTO.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/UserConstructorDTO.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class UserConstructorDTO
+{
+    /**
+     * @var string
+     */
+    private $id;
+    /**
+     * @var ?string
+     */
+    private $name;
+
+    /**
+     * @var int
+     */
+    private $age;
+
+    /**
+     * @var bool
+     */
+    private $constructor = false;
+
+    public function __construct(string $id, string $name, int $age = 30)
+    {
+        $this->id = $id;
+        $this->name = $name;
+        $this->age = $age;
+        $this->constructor = true;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getAge()
+    {
+        return $this->age;
+    }
+
+    public function getConstructor(): bool
+    {
+        return $this->constructor;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/UserDTO.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/UserDTO.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class UserDTO
+{
+    /**
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var int
+     */
+    public $age;
+
+    /**
+     * @var int
+     */
+    public $yearOfBirth;
+
+    /**
+     * @var string
+     */
+    public $email;
+
+    /**
+     * @var AddressDTO|null
+     */
+    public $address;
+
+    /**
+     * @var AddressDTO[]
+     */
+    public $addresses = [];
+
+    /**
+     * @var \DateTime|null
+     */
+    public $createdAt;
+
+    /**
+     * @var array|null
+     */
+    public $money;
+
+    /**
+     * @var array
+     */
+    public $languages = [];
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/UserDTOMerged.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/UserDTOMerged.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class UserDTOMerged
+{
+    /**
+     * @var mixed[]
+     */
+    protected $properties = [];
+
+    public function getProperties(): iterable
+    {
+        return $this->properties;
+    }
+
+    public function setProperties(iterable $properties): void
+    {
+        $this->properties = $properties;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/UserDTONoAge.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/UserDTONoAge.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class UserDTONoAge
+{
+    /**
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @var string
+     */
+    public $name;
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/UserDTONoName.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/UserDTONoName.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class UserDTONoName
+{
+    /**
+     * @var int
+     */
+    public $id;
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/UserDTOProperties.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/UserDTOProperties.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class UserDTOProperties
+{
+    /**
+     * @var mixed[]
+     */
+    protected $properties = [];
+
+    public function getProperties(): iterable
+    {
+        return $this->properties;
+    }
+
+    public function setProperties(iterable $properties): void
+    {
+        $this->properties = $properties;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/UserPartialConstructor.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/UserPartialConstructor.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class UserPartialConstructor
+{
+    /**
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    public $name;
+
+    /**
+     * @var string|int
+     */
+    public $age;
+
+    public function __construct($id, $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int|string $age
+     */
+    public function setAge($age): void
+    {
+        $this->age = $age;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/UserWithYearOfBirth.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/UserWithYearOfBirth.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Annotation\Groups;
+
+class UserWithYearOfBirth
+{
+    #[Groups('read')]
+    private int $id;
+
+    #[Groups('read')]
+    public string $name;
+
+    #[Groups('read')]
+    public string|int $age;
+
+    public function __construct($id, $name, $age)
+    {
+        $this->id = $id;
+        $this->name = $name;
+        $this->age = $age;
+    }
+
+    /**
+     * @Groups({"read"})
+     */
+    public function getYearOfBirth()
+    {
+        return ((int) date('Y')) - ((int) $this->age);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Fixtures/WrongParameters.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Fixtures/WrongParameters.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Fixtures;
+
+class WrongParameters
+{
+    /** @var string[]|null */
+    private $parameters;
+
+    /**
+     * @param string[]|null $parameters
+     */
+    public function __construct(array $parameters)
+    {
+        $this->setParameters($parameters);
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * @param string[]|null $parameters
+     */
+    public function setParameters(array $parameters): void
+    {
+        $this->parameters = $parameters;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Generator/UniqueVariableScopeTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Generator/UniqueVariableScopeTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Generator;
+
+use Symfony\Component\AutoMapper\Generator\UniqueVariableScope;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class UniqueVariableScopeTest extends TestCase
+{
+    public function testVariableNameNotEquals(): void
+    {
+        $uniqueVariable = new UniqueVariableScope();
+        $var1 = $uniqueVariable->getUniqueName('value');
+        $var2 = $uniqueVariable->getUniqueName('value');
+        $var3 = $uniqueVariable->getUniqueName('VALUE');
+
+        self::assertNotSame($var1, $var2);
+        self::assertNotSame($var1, $var3);
+        self::assertNotSame($var2, $var3);
+        self::assertNotSame(strtolower($var1), strtolower($var3));
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/MapperContextTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/MapperContextTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests;
+
+use Symfony\Component\AutoMapper\Exception\CircularReferenceException;
+use Symfony\Component\AutoMapper\MapperContext;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class MapperContextTest extends TestCase
+{
+    public function testIsAllowedAttribute(): void
+    {
+        $context = new MapperContext();
+        $context->setAllowedAttributes(['id', 'age']);
+        $context->setIgnoredAttributes(['age']);
+
+        self::assertTrue(MapperContext::isAllowedAttribute($context->toArray(), 'id', 1));
+        self::assertFalse(MapperContext::isAllowedAttribute($context->toArray(), 'age', 29));
+        self::assertFalse(MapperContext::isAllowedAttribute($context->toArray(), 'name', 'Baptiste'));
+    }
+
+    public function testCircularReferenceLimit(): void
+    {
+        // with no circularReferenceLimit
+        $object = new \stdClass();
+        $context = MapperContext::withReference([], 'reference', $object);
+
+        self::assertTrue(MapperContext::shouldHandleCircularReference($context, 'reference'));
+
+        // with circularReferenceLimit
+        $object = new \stdClass();
+        $context = new MapperContext();
+        $context->setCircularReferenceLimit(3);
+        $context = MapperContext::withReference($context->toArray(), 'reference', $object);
+
+        for ($i = 0; $i <= 2; ++$i) {
+            if (2 === $i) {
+                self::assertTrue(MapperContext::shouldHandleCircularReference($context, 'reference'));
+                break;
+            }
+
+            self::assertFalse(MapperContext::shouldHandleCircularReference($context, 'reference'));
+
+            // fake handleCircularReference to increment countReferenceRegistry
+            MapperContext::handleCircularReference($context, 'reference', $object);
+        }
+
+        self::expectException(CircularReferenceException::class);
+        self::expectExceptionMessage('A circular reference has been detected when mapping the object of type "stdClass" (configured limit: 3)');
+        MapperContext::handleCircularReference($context, 'reference', $object);
+    }
+
+    public function testCircularReferenceHandler(): void
+    {
+        $object = new \stdClass();
+        $context = new MapperContext();
+        $context->setCircularReferenceHandler(function ($object) {
+            return $object;
+        });
+        $context = MapperContext::withReference($context->toArray(), 'reference', $object);
+
+        self::assertTrue(MapperContext::shouldHandleCircularReference($context, 'reference'));
+        self::assertEquals($object, MapperContext::handleCircularReference($context, 'reference', $object));
+    }
+
+    public function testConstructorArgument(): void
+    {
+        $context = new MapperContext();
+        $context->setConstructorArgument(Fixtures\User::class, 'id', 10);
+        $context->setConstructorArgument(Fixtures\User::class, 'age', 50);
+
+        self::assertTrue(MapperContext::hasConstructorArgument($context->toArray(), Fixtures\User::class, 'id'));
+        self::assertFalse(MapperContext::hasConstructorArgument($context->toArray(), Fixtures\User::class, 'name'));
+        self::assertTrue(MapperContext::hasConstructorArgument($context->toArray(), Fixtures\User::class, 'age'));
+
+        self::assertEquals(10, MapperContext::getConstructorArgument($context->toArray(), Fixtures\User::class, 'id'));
+        self::assertEquals(50, MapperContext::getConstructorArgument($context->toArray(), Fixtures\User::class, 'age'));
+
+        self::assertNull(MapperContext::getConstructorArgument($context->toArray(), Fixtures\User::class, 'name'));
+    }
+
+    public function testGroups(): void
+    {
+        $expected = ['group1', 'group4'];
+        $context = new MapperContext();
+        $context->setGroups($expected);
+
+        self::assertEquals($expected, $context->toArray()[MapperContext::GROUPS]);
+        self::assertContains('group1', $context->toArray()[MapperContext::GROUPS]);
+        self::assertNotContains('group2', $context->toArray()[MapperContext::GROUPS]);
+    }
+
+    public function testTargetToPopulate(): void
+    {
+        $object = new \stdClass();
+        $context = new MapperContext();
+        $context->setTargetToPopulate($object);
+
+        self::assertSame($object, $context->toArray()[MapperContext::TARGET_TO_POPULATE]);
+    }
+
+    public function testWithNewContextIgnoredAttributesNested(): void
+    {
+        $context = [
+            MapperContext::IGNORED_ATTRIBUTES => [
+                'foo' => ['bar'],
+                'baz',
+            ],
+        ];
+
+        $newContext = MapperContext::withNewContext($context, 'foo');
+
+        self::assertEquals(['bar'], $newContext[MapperContext::IGNORED_ATTRIBUTES]);
+    }
+
+    public function testWithNewContextAllowedAttributesNested(): void
+    {
+        $context = [
+            MapperContext::ALLOWED_ATTRIBUTES => [
+                'foo' => ['bar'],
+                'baz',
+            ],
+        ];
+
+        self::assertTrue(MapperContext::isAllowedAttribute($context, 'foo', 1));
+        $newContext = MapperContext::withNewContext($context, 'foo');
+
+        self::assertEquals(['bar'], $newContext[MapperContext::ALLOWED_ATTRIBUTES]);
+    }
+
+    public function testSkipNullValues(): void
+    {
+        $context = [MapperContext::SKIP_NULL_VALUES => true];
+        self::assertFalse(MapperContext::isAllowedAttribute($context, 'id', null));
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/MapperGeneratorMetadataFactoryTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/MapperGeneratorMetadataFactoryTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Symfony\Component\AutoMapper\Extractor\FromSourceMappingExtractor;
+use Symfony\Component\AutoMapper\Extractor\FromTargetMappingExtractor;
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\Extractor\SourceTargetMappingExtractor;
+use Symfony\Component\AutoMapper\MapperGeneratorMetadataFactory;
+use Symfony\Component\AutoMapper\MapperGeneratorMetadataFactoryInterface;
+use Symfony\Component\AutoMapper\Transformer\ArrayTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\BuiltinTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\ChainTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\DateTimeTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\MultipleTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\NullableTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\ObjectTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\UniqueTypeTransformerFactory;
+use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class MapperGeneratorMetadataFactoryTest extends AutoMapperBase
+{
+    protected MapperGeneratorMetadataFactoryInterface $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $reflectionExtractor = new ReflectionExtractor(null, null, null, true, ReflectionExtractor::ALLOW_PUBLIC | ReflectionExtractor::ALLOW_PROTECTED | ReflectionExtractor::ALLOW_PRIVATE);
+
+        $phpStanExtractor = new PhpStanExtractor();
+        $propertyInfoExtractor = new PropertyInfoExtractor(
+            [$reflectionExtractor],
+            [$phpStanExtractor, $reflectionExtractor],
+            [$reflectionExtractor],
+            [$reflectionExtractor]
+        );
+
+        $transformerFactory = new ChainTransformerFactory();
+        $sourceTargetMappingExtractor = new SourceTargetMappingExtractor(
+            $propertyInfoExtractor,
+            $reflectionExtractor,
+            $reflectionExtractor,
+            $transformerFactory,
+            $classMetadataFactory
+        );
+
+        $fromTargetMappingExtractor = new FromTargetMappingExtractor(
+            $propertyInfoExtractor,
+            $reflectionExtractor,
+            $reflectionExtractor,
+            $transformerFactory,
+            $classMetadataFactory
+        );
+
+        $fromSourceMappingExtractor = new FromSourceMappingExtractor(
+            $propertyInfoExtractor,
+            $reflectionExtractor,
+            $reflectionExtractor,
+            $transformerFactory,
+            $classMetadataFactory
+        );
+
+        $this->factory = new MapperGeneratorMetadataFactory(
+            $sourceTargetMappingExtractor,
+            $fromSourceMappingExtractor,
+            $fromTargetMappingExtractor
+        );
+
+        $transformerFactory->addTransformerFactory(new MultipleTransformerFactory($transformerFactory));
+        $transformerFactory->addTransformerFactory(new NullableTransformerFactory($transformerFactory));
+        $transformerFactory->addTransformerFactory(new UniqueTypeTransformerFactory($transformerFactory));
+        $transformerFactory->addTransformerFactory(new DateTimeTransformerFactory());
+        $transformerFactory->addTransformerFactory(new BuiltinTransformerFactory());
+        $transformerFactory->addTransformerFactory(new ArrayTransformerFactory($transformerFactory));
+        $transformerFactory->addTransformerFactory(new ObjectTransformerFactory($this->autoMapper));
+    }
+
+    public function testCreateObjectToArray(): void
+    {
+        $userReflection = new \ReflectionClass(Fixtures\User::class);
+
+        $metadata = $this->factory->create($this->autoMapper, Fixtures\User::class, 'array');
+        self::assertFalse($metadata->hasConstructor());
+        self::assertTrue($metadata->shouldCheckAttributes());
+        self::assertFalse($metadata->isTargetCloneable());
+        self::assertEquals(Fixtures\User::class, $metadata->getSource());
+        self::assertEquals('array', $metadata->getTarget());
+        self::assertCount(\count($userReflection->getProperties()), $metadata->getPropertiesMapping());
+        self::assertInstanceOf(PropertyMapping::class, $metadata->getPropertyMapping('id'));
+        self::assertInstanceOf(PropertyMapping::class, $metadata->getPropertyMapping('name'));
+        self::assertInstanceOf(PropertyMapping::class, $metadata->getPropertyMapping('email'));
+    }
+
+    public function testCreateArrayToObject(): void
+    {
+        $userReflection = new \ReflectionClass(Fixtures\User::class);
+
+        $metadata = $this->factory->create($this->autoMapper, 'array', Fixtures\User::class);
+        self::assertTrue($metadata->hasConstructor());
+        self::assertTrue($metadata->shouldCheckAttributes());
+        self::assertTrue($metadata->isTargetCloneable());
+        self::assertEquals('array', $metadata->getSource());
+        self::assertEquals(Fixtures\User::class, $metadata->getTarget());
+        self::assertCount(\count($userReflection->getProperties()), $metadata->getPropertiesMapping());
+        self::assertInstanceOf(PropertyMapping::class, $metadata->getPropertyMapping('id'));
+        self::assertInstanceOf(PropertyMapping::class, $metadata->getPropertyMapping('name'));
+        self::assertInstanceOf(PropertyMapping::class, $metadata->getPropertyMapping('email'));
+    }
+
+    public function testCreateWithBothObjects(): void
+    {
+        $metadata = $this->factory->create($this->autoMapper, Fixtures\UserConstructorDTO::class, Fixtures\User::class);
+        self::assertTrue($metadata->hasConstructor());
+        self::assertTrue($metadata->shouldCheckAttributes());
+        self::assertTrue($metadata->isTargetCloneable());
+        self::assertEquals(Fixtures\UserConstructorDTO::class, $metadata->getSource());
+        self::assertEquals(Fixtures\User::class, $metadata->getTarget());
+        self::assertInstanceOf(PropertyMapping::class, $metadata->getPropertyMapping('id'));
+        self::assertInstanceOf(PropertyMapping::class, $metadata->getPropertyMapping('name'));
+        self::assertNull($metadata->getPropertyMapping('email'));
+    }
+
+    public function testHasNotConstructor(): void
+    {
+        $metadata = $this->factory->create($this->autoMapper, 'array', Fixtures\UserDTO::class);
+
+        self::assertFalse($metadata->hasConstructor());
+    }
+
+    /**
+     * @requires PHP 8.2
+     */
+    public function testTargetIsReadOnlyClass(): void
+    {
+        $metadata = $this->factory->create($this->autoMapper, 'array', Fixtures\AddressDTOReadonlyClass::class);
+
+        self::assertEquals(Fixtures\AddressDTOReadonlyClass::class, $metadata->getTarget());
+        self::assertTrue($metadata->isTargetReadOnlyClass());
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Normalizer/AutoMapperNormalizerTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Normalizer/AutoMapperNormalizerTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Normalizer;
+
+use Symfony\Component\AutoMapper\AutoMapperInterface;
+use Symfony\Component\AutoMapper\AutoMapperRegistryInterface;
+use Symfony\Component\AutoMapper\MapperContext;
+use Symfony\Component\AutoMapper\MapperInterface;
+use Symfony\Component\AutoMapper\Normalizer\AutoMapperNormalizer;
+use Symfony\Component\AutoMapper\Tests\Fixtures;
+use Symfony\Component\AutoMapper\Tests\AutoMapperBase;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class AutoMapperNormalizerTest extends AutoMapperBase
+{
+    protected AutoMapperNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->normalizer = new AutoMapperNormalizer($this->autoMapper);
+    }
+
+    public function testNormalize(): void
+    {
+        $object = new Fixtures\User(1, 'Jack', 37);
+        $expected = ['id' => 1, 'name' => 'Jack', 'age' => 37];
+
+        $normalized = $this->normalizer->normalize($object);
+        self::assertIsArray($normalized);
+        self::assertEquals($expected['id'], $normalized['id']);
+        self::assertEquals($expected['name'], $normalized['name']);
+        self::assertEquals($expected['age'], $normalized['age']);
+    }
+
+    public function testDenormalize(): void
+    {
+        $source = ['id' => 1, 'name' => 'Jack', 'age' => 37];
+
+        /** @var Fixtures\User $denormalized */
+        $denormalized = $this->normalizer->denormalize($source, Fixtures\User::class);
+        self::assertInstanceOf(Fixtures\User::class, $denormalized);
+        self::assertEquals($source['id'], $denormalized->getId());
+        self::assertEquals($source['name'], $denormalized->name);
+        self::assertEquals($source['age'], $denormalized->age);
+    }
+
+    public function testSupportsNormalization(): void
+    {
+        self::assertFalse($this->normalizer->supportsNormalization(['foo']));
+        self::assertFalse($this->normalizer->supportsNormalization('{"foo":1}'));
+
+        $object = new Fixtures\User(1, 'Jack', 37);
+        self::assertTrue($this->normalizer->supportsNormalization($object));
+
+        $stdClass = new \stdClass();
+        $stdClass->id = 1;
+        $stdClass->name = 'Jack';
+        $stdClass->age = 37;
+        self::assertFalse($this->normalizer->supportsNormalization($stdClass));
+    }
+
+    public function testSupportsDenormalization(): void
+    {
+        self::assertTrue($this->normalizer->supportsDenormalization(['foo' => 1], 'array'));
+        self::assertTrue($this->normalizer->supportsDenormalization(['foo' => 1], 'json'));
+
+        $user = ['id' => 1, 'name' => 'Jack', 'age' => 37];
+        self::assertTrue($this->normalizer->supportsDenormalization($user, Fixtures\User::class));
+        self::assertTrue($this->normalizer->supportsDenormalization($user, \stdClass::class));
+    }
+
+    public function testNormalizeWithNoReturnType(): void
+    {
+        $object = new Fixtures\UserWithYearOfBirth(1, 'Foo', 37);
+        $expected = ['id' => 1, 'name' => 'Foo', 'age' => 37, 'yearOfBirth' => (((int) date('Y')) - 37)];
+
+        $normalized = $this->normalizer->normalize($object, null, ['groups' => ['read']]);
+        self::assertIsArray($normalized);
+        self::assertEquals($expected['id'], $normalized['id']);
+        self::assertEquals($expected['name'], $normalized['name']);
+        self::assertEquals($expected['age'], $normalized['age']);
+        self::assertEquals($expected['yearOfBirth'], $normalized['yearOfBirth']);
+    }
+
+    public function testItUsesSerializerContext(): void
+    {
+        $normalizer = new AutoMapperNormalizer(
+            new class() implements AutoMapperInterface, AutoMapperRegistryInterface {
+                public function map(null|array|object $source, string|array|object $target, array $context = []): null|array|object
+                {
+                    return $context;
+                }
+
+                public function getMapper(string $source, string $target): MapperInterface
+                {
+                    throw new \RuntimeException('unexpected');
+                }
+
+                public function hasMapper(string $source, string $target): bool
+                {
+                    return true;
+                }
+            }
+        );
+
+        $context = $normalizer->normalize(new Fixtures\User(1, 'Jack', 37), 'array', [
+            AbstractNormalizer::GROUPS => ['foo'],
+            AbstractNormalizer::ATTRIBUTES => ['foo'],
+            AbstractNormalizer::IGNORED_ATTRIBUTES => ['foo'],
+            AbstractNormalizer::OBJECT_TO_POPULATE => 'some-object',
+            AbstractNormalizer::CIRCULAR_REFERENCE_LIMIT => 1,
+            AbstractNormalizer::CIRCULAR_REFERENCE_HANDLER => 'circular-reference-handler',
+            'custom-context' => 'some custom context',
+            MapperContext::ALLOWED_ATTRIBUTES => 'some ignored context',
+        ]);
+
+        self::assertSame(
+            [
+                MapperContext::GROUPS => ['foo'],
+                MapperContext::ALLOWED_ATTRIBUTES => ['foo'],
+                MapperContext::IGNORED_ATTRIBUTES => ['foo'],
+                MapperContext::TARGET_TO_POPULATE => 'some-object',
+                MapperContext::CIRCULAR_REFERENCE_LIMIT => 1,
+                MapperContext::CIRCULAR_REFERENCE_HANDLER => 'circular-reference-handler',
+                'custom-context' => 'some custom context',
+            ],
+            $context
+        );
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Transformer/ArrayTransformerFactoryTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Transformer/ArrayTransformerFactoryTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Transformer;
+
+use Symfony\Component\AutoMapper\MapperMetadata;
+use Symfony\Component\AutoMapper\Transformer\ArrayTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\ChainTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\CopyTransformer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class ArrayTransformerFactoryTest extends TestCase
+{
+    public function testGetTransformer(): void
+    {
+        $chainFactory = new ChainTransformerFactory();
+        $factory = new ArrayTransformerFactory($chainFactory);
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $transformer = $factory->getTransformer([new Type('array', false, null, true)], [new Type('array', false, null, true)], $mapperMetadata);
+
+        self::assertInstanceOf(CopyTransformer::class, $transformer);
+    }
+
+    public function testNoTransformerTargetNoCollection(): void
+    {
+        $chainFactory = new ChainTransformerFactory();
+        $factory = new ArrayTransformerFactory($chainFactory);
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $transformer = $factory->getTransformer([new Type('array', false, null, true)], [new Type('string')], $mapperMetadata);
+
+        self::assertNull($transformer);
+    }
+
+    public function testNoTransformerSourceNoCollection(): void
+    {
+        $chainFactory = new ChainTransformerFactory();
+        $factory = new ArrayTransformerFactory($chainFactory);
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $transformer = $factory->getTransformer([new Type('string')], [new Type('array', false, null, true)], $mapperMetadata);
+
+        self::assertNull($transformer);
+    }
+
+    public function testNoTransformerIfNoSubTypeTransformerNoCollection(): void
+    {
+        $chainFactory = new ChainTransformerFactory();
+        $factory = new ArrayTransformerFactory();
+        $factory->setChainTransformerFactory($chainFactory);
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $stringType = new Type('string');
+        $transformer = $factory->getTransformer([new Type('array', false, null, true, null, $stringType)], [new Type('array', false, null, true, null, $stringType)], $mapperMetadata);
+
+        self::assertNull($transformer);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Transformer/ArrayTransformerTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Transformer/ArrayTransformerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Transformer;
+
+use Symfony\Component\AutoMapper\Transformer\ArrayTransformer;
+use Symfony\Component\AutoMapper\Transformer\BuiltinTransformer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class ArrayTransformerTest extends TestCase
+{
+    use EvalTransformerTrait;
+
+    public function testArrayToArray(): void
+    {
+        $transformer = new ArrayTransformer(new BuiltinTransformer(new Type('string'), [new Type('string')]));
+        $output = $this->evalTransformer($transformer, ['test']);
+
+        self::assertEquals(['test'], $output);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Transformer/BuiltinTransformerFactoryTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Transformer/BuiltinTransformerFactoryTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Transformer;
+
+use Symfony\Component\AutoMapper\MapperMetadata;
+use Symfony\Component\AutoMapper\Transformer\BuiltinTransformer;
+use Symfony\Component\AutoMapper\Transformer\BuiltinTransformerFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class BuiltinTransformerFactoryTest extends TestCase
+{
+    public function testGetTransformer(): void
+    {
+        $factory = new BuiltinTransformerFactory();
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $transformer = $factory->getTransformer([new Type('string')], [new Type('string')], $mapperMetadata);
+
+        self::assertInstanceOf(BuiltinTransformer::class, $transformer);
+
+        $transformer = $factory->getTransformer([new Type('bool')], [new Type('string')], $mapperMetadata);
+
+        self::assertInstanceOf(BuiltinTransformer::class, $transformer);
+    }
+
+    public function testNoTransformer(): void
+    {
+        $factory = new BuiltinTransformerFactory();
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $transformer = $factory->getTransformer([], [new Type('string')], $mapperMetadata);
+
+        self::assertNull($transformer);
+
+        $transformer = $factory->getTransformer(null, [new Type('string')], $mapperMetadata);
+
+        self::assertNull($transformer);
+
+        $transformer = $factory->getTransformer(['test'], [new Type('string')], $mapperMetadata);
+
+        self::assertNull($transformer);
+
+        $transformer = $factory->getTransformer([new Type('string'), new Type('string')], [new Type('string')], $mapperMetadata);
+
+        self::assertNull($transformer);
+
+        $transformer = $factory->getTransformer([new Type('array')], [new Type('string')], $mapperMetadata);
+
+        self::assertNull($transformer);
+
+        $transformer = $factory->getTransformer([new Type('object')], [new Type('string')], $mapperMetadata);
+
+        self::assertNull($transformer);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Transformer/BuiltinTransformerTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Transformer/BuiltinTransformerTest.php
@@ -1,0 +1,293 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Transformer;
+
+use Symfony\Component\AutoMapper\Transformer\BuiltinTransformer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class BuiltinTransformerTest extends TestCase
+{
+    use EvalTransformerTrait;
+
+    public function testStringToString()
+    {
+        $transformer = new BuiltinTransformer(new Type('string'), [new Type('string')]);
+        $output = $this->evalTransformer($transformer, 'foo');
+
+        self::assertSame('foo', $output);
+    }
+
+    public function testStringToArray()
+    {
+        $transformer = new BuiltinTransformer(new Type('string'), [new Type('array')]);
+        $output = $this->evalTransformer($transformer, 'foo');
+
+        self::assertSame(['foo'], $output);
+    }
+
+    public function testStringToIterable()
+    {
+        $transformer = new BuiltinTransformer(new Type('string'), [new Type('iterable')]);
+        $output = $this->evalTransformer($transformer, 'foo');
+
+        self::assertSame(['foo'], $output);
+    }
+
+    public function testStringToFloat()
+    {
+        $transformer = new BuiltinTransformer(new Type('string'), [new Type('float')]);
+        $output = $this->evalTransformer($transformer, '12.2');
+
+        self::assertSame(12.2, $output);
+    }
+
+    public function testStringToInt()
+    {
+        $transformer = new BuiltinTransformer(new Type('string'), [new Type('int')]);
+        $output = $this->evalTransformer($transformer, '12');
+
+        self::assertSame(12, $output);
+    }
+
+    public function testStringToBool()
+    {
+        $transformer = new BuiltinTransformer(new Type('string'), [new Type('bool')]);
+        $output = $this->evalTransformer($transformer, 'foo');
+
+        self::assertTrue($output);
+
+        $output = $this->evalTransformer($transformer, '');
+
+        self::assertFalse($output);
+    }
+
+    public function testBoolToInt()
+    {
+        $transformer = new BuiltinTransformer(new Type('bool'), [new Type('int')]);
+        $output = $this->evalTransformer($transformer, true);
+
+        self::assertSame(1, $output);
+
+        $output = $this->evalTransformer($transformer, false);
+
+        self::assertSame(0, $output);
+    }
+
+    public function testBoolToString()
+    {
+        $transformer = new BuiltinTransformer(new Type('bool'), [new Type('string')]);
+
+        $output = $this->evalTransformer($transformer, true);
+
+        self::assertSame('1', $output);
+
+        $output = $this->evalTransformer($transformer, false);
+
+        self::assertSame('', $output);
+    }
+
+    public function testBoolToFloat()
+    {
+        $transformer = new BuiltinTransformer(new Type('bool'), [new Type('float')]);
+
+        $output = $this->evalTransformer($transformer, true);
+
+        self::assertSame(1.0, $output);
+
+        $output = $this->evalTransformer($transformer, false);
+
+        self::assertSame(0.0, $output);
+    }
+
+    public function testBoolToArray()
+    {
+        $transformer = new BuiltinTransformer(new Type('bool'), [new Type('array')]);
+
+        $output = $this->evalTransformer($transformer, true);
+
+        self::assertSame([true], $output);
+
+        $output = $this->evalTransformer($transformer, false);
+
+        self::assertSame([false], $output);
+    }
+
+    public function testBoolToIterable()
+    {
+        $transformer = new BuiltinTransformer(new Type('bool'), [new Type('iterable')]);
+
+        $output = $this->evalTransformer($transformer, true);
+
+        self::assertSame([true], $output);
+
+        $output = $this->evalTransformer($transformer, false);
+
+        self::assertSame([false], $output);
+    }
+
+    public function testBoolToBool()
+    {
+        $transformer = new BuiltinTransformer(new Type('bool'), [new Type('bool')]);
+
+        $output = $this->evalTransformer($transformer, true);
+
+        self::assertTrue($output);
+
+        $output = $this->evalTransformer($transformer, false);
+
+        self::assertFalse($output);
+    }
+
+    public function testFloatToString()
+    {
+        $transformer = new BuiltinTransformer(new Type('float'), [new Type('string')]);
+
+        $output = $this->evalTransformer($transformer, 12.23);
+
+        self::assertSame('12.23', $output);
+    }
+
+    public function testFloatToInt()
+    {
+        $transformer = new BuiltinTransformer(new Type('float'), [new Type('int')]);
+
+        $output = $this->evalTransformer($transformer, 12.23);
+
+        self::assertSame(12, $output);
+    }
+
+    public function testFloatToBool()
+    {
+        $transformer = new BuiltinTransformer(new Type('float'), [new Type('bool')]);
+
+        $output = $this->evalTransformer($transformer, 12.23);
+
+        self::assertTrue($output);
+
+        $output = $this->evalTransformer($transformer, 0.0);
+
+        self::assertFalse($output);
+    }
+
+    public function testFloatToArray()
+    {
+        $transformer = new BuiltinTransformer(new Type('float'), [new Type('array')]);
+
+        $output = $this->evalTransformer($transformer, 12.23);
+
+        self::assertSame([12.23], $output);
+    }
+
+    public function testFloatToIterable()
+    {
+        $transformer = new BuiltinTransformer(new Type('float'), [new Type('iterable')]);
+
+        $output = $this->evalTransformer($transformer, 12.23);
+
+        self::assertSame([12.23], $output);
+    }
+
+    public function testFloatToFloat()
+    {
+        $transformer = new BuiltinTransformer(new Type('float'), [new Type('float')]);
+
+        $output = $this->evalTransformer($transformer, 12.23);
+
+        self::assertSame(12.23, $output);
+    }
+
+    public function testIntToInt()
+    {
+        $transformer = new BuiltinTransformer(new Type('int'), [new Type('int')]);
+
+        $output = $this->evalTransformer($transformer, 12);
+
+        self::assertSame(12, $output);
+    }
+
+    public function testIntToFloat()
+    {
+        $transformer = new BuiltinTransformer(new Type('int'), [new Type('float')]);
+
+        $output = $this->evalTransformer($transformer, 12);
+
+        self::assertSame(12.0, $output);
+    }
+
+    public function testIntToString()
+    {
+        $transformer = new BuiltinTransformer(new Type('int'), [new Type('string')]);
+
+        $output = $this->evalTransformer($transformer, 12);
+
+        self::assertSame('12', $output);
+    }
+
+    public function testIntToBool()
+    {
+        $transformer = new BuiltinTransformer(new Type('int'), [new Type('bool')]);
+
+        $output = $this->evalTransformer($transformer, 12);
+
+        self::assertTrue($output);
+
+        $output = $this->evalTransformer($transformer, 0);
+
+        self::assertFalse($output);
+    }
+
+    public function testIntToArray()
+    {
+        $transformer = new BuiltinTransformer(new Type('int'), [new Type('array')]);
+
+        $output = $this->evalTransformer($transformer, 12);
+
+        self::assertSame([12], $output);
+    }
+
+    public function testIntToIterable()
+    {
+        $transformer = new BuiltinTransformer(new Type('int'), [new Type('iterable')]);
+
+        $output = $this->evalTransformer($transformer, 12);
+
+        self::assertSame([12], $output);
+    }
+
+    public function testIterableToArray()
+    {
+        $transformer = new BuiltinTransformer(new Type('iterable'), [new Type('array')]);
+
+        $closure = function () {
+            yield 1;
+            yield 2;
+        };
+
+        $output = $this->evalTransformer($transformer, $closure());
+
+        self::assertSame([1, 2], $output);
+    }
+
+    public function testArrayToIterable()
+    {
+        $transformer = new BuiltinTransformer(new Type('array'), [new Type('iterable')]);
+        $output = $this->evalTransformer($transformer, [1, 2]);
+
+        self::assertSame([1, 2], $output);
+    }
+
+    public function testToUnknowCast()
+    {
+        $transformer = new BuiltinTransformer(new Type('callable'), [new Type('string')]);
+
+        $output = $this->evalTransformer($transformer, function ($test) {
+            return $test;
+        });
+
+        self::assertIsCallable($output);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Transformer/CallbackTransformerTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Transformer/CallbackTransformerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Transformer;
+
+use Symfony\Component\AutoMapper\Transformer\CallbackTransformer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class CallbackTransformerTest extends TestCase
+{
+    use EvalTransformerTrait;
+
+    public function testCallbackTransform()
+    {
+        $transformer = new CallbackTransformer('test');
+        $function = $this->createTransformerFunction($transformer);
+        $class = new class() {
+            public $callbacks;
+
+            public function __construct()
+            {
+                $this->callbacks['test'] = function ($input) {
+                    return 'output';
+                };
+            }
+        };
+
+        $transform = \Closure::bind($function, $class);
+
+        $output = $transform('input');
+
+        self::assertEquals('output', $output);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Transformer/ChainTransformerFactoryTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Transformer/ChainTransformerFactoryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Transformer;
+
+use Symfony\Component\AutoMapper\MapperMetadata;
+use Symfony\Component\AutoMapper\Transformer\ChainTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\CopyTransformer;
+use Symfony\Component\AutoMapper\Transformer\TransformerFactoryInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class ChainTransformerFactoryTest extends TestCase
+{
+    public function testGetTransformer()
+    {
+        $chainTransformerFactory = new ChainTransformerFactory();
+        $transformer = new CopyTransformer();
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+        $subTransformer = $this
+            ->getMockBuilder(TransformerFactoryInterface::class)
+            ->getMock()
+        ;
+
+        $subTransformer->expects($this->any())->method('getTransformer')->willReturn($transformer);
+        $chainTransformerFactory->addTransformerFactory($subTransformer);
+
+        $transformerReturned = $chainTransformerFactory->getTransformer([], [], $mapperMetadata);
+
+        self::assertSame($transformer, $transformerReturned);
+    }
+
+    public function testNoTransformer()
+    {
+        $chainTransformerFactory = new ChainTransformerFactory();
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+        $subTransformer = $this
+            ->getMockBuilder(TransformerFactoryInterface::class)
+            ->getMock()
+        ;
+
+        $subTransformer->expects($this->any())->method('getTransformer')->willReturn(null);
+        $chainTransformerFactory->addTransformerFactory($subTransformer);
+
+        $transformerReturned = $chainTransformerFactory->getTransformer([], [], $mapperMetadata);
+
+        self::assertNull($transformerReturned);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Transformer/CopyTransformerTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Transformer/CopyTransformerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Transformer;
+
+use Symfony\Component\AutoMapper\Transformer\CopyTransformer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class CopyTransformerTest extends TestCase
+{
+    use EvalTransformerTrait;
+
+    public function testCopyTransformer()
+    {
+        $transformer = new CopyTransformer();
+
+        $output = $this->evalTransformer($transformer, 'foo');
+
+        self::assertSame('foo', $output);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Transformer/DateTimeImmutableToMutableTransformerTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Transformer/DateTimeImmutableToMutableTransformerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Transformer;
+
+use Symfony\Component\AutoMapper\Transformer\DateTimeImmutableToMutableTransformer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class DateTimeImmutableToMutableTransformerTest extends TestCase
+{
+    use EvalTransformerTrait;
+
+    public function testDateTimeImmutableTransformer()
+    {
+        $transformer = new DateTimeImmutableToMutableTransformer();
+
+        $date = new \DateTimeImmutable();
+        $output = $this->evalTransformer($transformer, $date);
+
+        self::assertInstanceOf(\DateTime::class, $output);
+        self::assertSame($date->format(\DateTime::RFC3339), $output->format(\DateTime::RFC3339));
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Transformer/DateTimeMutableToImmutableTransformerTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Transformer/DateTimeMutableToImmutableTransformerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Transformer;
+
+use Symfony\Component\AutoMapper\Transformer\DateTimeMutableToImmutableTransformer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class DateTimeMutableToImmutableTransformerTest extends TestCase
+{
+    use EvalTransformerTrait;
+
+    public function testDateTimeImmutableTransformer()
+    {
+        $transformer = new DateTimeMutableToImmutableTransformer();
+
+        $date = new \DateTime();
+        $output = $this->evalTransformer($transformer, $date);
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $output);
+        self::assertSame($date->format(\DateTime::RFC3339), $output->format(\DateTime::RFC3339));
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Transformer/DateTimeToStringTransformerTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Transformer/DateTimeToStringTransformerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Transformer;
+
+use Symfony\Component\AutoMapper\Transformer\DateTimeToStringTransformer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class DateTimeToStringTransformerTest extends TestCase
+{
+    use EvalTransformerTrait;
+
+    public function testDateTimeTransformer()
+    {
+        $transformer = new DateTimeToStringTransformer();
+
+        $date = new \DateTime();
+        $output = $this->evalTransformer($transformer, new \DateTime());
+
+        self::assertSame($date->format(\DateTime::RFC3339), $output);
+    }
+
+    public function testDateTimeTransformerCustomFormat()
+    {
+        $transformer = new DateTimeToStringTransformer(\DateTime::COOKIE);
+
+        $date = new \DateTime();
+        $output = $this->evalTransformer($transformer, new \DateTime());
+
+        self::assertSame($date->format(\DateTime::COOKIE), $output);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Transformer/DateTimeTransformerFactoryTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Transformer/DateTimeTransformerFactoryTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Transformer;
+
+use Symfony\Component\AutoMapper\MapperMetadata;
+use Symfony\Component\AutoMapper\Transformer\CopyTransformer;
+use Symfony\Component\AutoMapper\Transformer\DateTimeImmutableToMutableTransformer;
+use Symfony\Component\AutoMapper\Transformer\DateTimeMutableToImmutableTransformer;
+use Symfony\Component\AutoMapper\Transformer\DateTimeToStringTransformer;
+use Symfony\Component\AutoMapper\Transformer\DateTimeTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\StringToDateTimeTransformer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class DateTimeTransformerFactoryTest extends TestCase
+{
+    public function testGetTransformer()
+    {
+        $factory = new DateTimeTransformerFactory();
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $transformer = $factory->getTransformer([new Type('object', false, \DateTime::class)], [new Type('object', false, \DateTime::class)], $mapperMetadata);
+
+        self::assertNotNull($transformer);
+        self::assertInstanceOf(CopyTransformer::class, $transformer);
+
+        $transformer = $factory->getTransformer([new Type('object', false, \DateTime::class)], [new Type('string')], $mapperMetadata);
+
+        self::assertNotNull($transformer);
+        self::assertInstanceOf(DateTimeToStringTransformer::class, $transformer);
+
+        $transformer = $factory->getTransformer([new Type('string')], [new Type('object', false, \DateTime::class)], $mapperMetadata);
+
+        self::assertNotNull($transformer);
+        self::assertInstanceOf(StringToDateTimeTransformer::class, $transformer);
+    }
+
+    public function testGetTransformerImmutable()
+    {
+        $factory = new DateTimeTransformerFactory();
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $transformer = $factory->getTransformer([new Type('object', false, \DateTimeImmutable::class)], [new Type('object', false, \DateTime::class)], $mapperMetadata);
+
+        self::assertNotNull($transformer);
+        self::assertInstanceOf(DateTimeImmutableToMutableTransformer::class, $transformer);
+    }
+
+    public function testGetTransformerMutable()
+    {
+        $factory = new DateTimeTransformerFactory();
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $transformer = $factory->getTransformer([new Type('object', false, \DateTime::class)], [new Type('object', false, \DateTimeImmutable::class)], $mapperMetadata);
+
+        self::assertNotNull($transformer);
+        self::assertInstanceOf(DateTimeMutableToImmutableTransformer::class, $transformer);
+    }
+
+    public function testNoTransformer()
+    {
+        $factory = new DateTimeTransformerFactory();
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $transformer = $factory->getTransformer([new Type('string')], [new Type('string')], $mapperMetadata);
+
+        self::assertNull($transformer);
+
+        $transformer = $factory->getTransformer([new Type('object', false, \DateTime::class)], [new Type('bool')], $mapperMetadata);
+
+        self::assertNull($transformer);
+
+        $transformer = $factory->getTransformer([new Type('bool')], [new Type('object', false, \DateTime::class)], $mapperMetadata);
+
+        self::assertNull($transformer);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Transformer/EnumTransformerFactoryTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Transformer/EnumTransformerFactoryTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Transformer;
+
+use Symfony\Component\AutoMapper\MapperMetadata;
+use Symfony\Component\AutoMapper\Transformer\CopyTransformer;
+use Symfony\Component\AutoMapper\Transformer\EnumTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\SourceEnumTransformer;
+use Symfony\Component\AutoMapper\Transformer\TargetEnumTransformer;
+use Symfony\Component\AutoMapper\Transformer\TransformerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\AutoMapper\Tests\Fixtures\AddressType;
+use Symfony\Component\AutoMapper\Tests\Fixtures\UnitAddressType;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class EnumTransformerFactoryTest extends TestCase
+{
+    public function testNoTransformer(): void
+    {
+        $transformer = $this->makeTransformer(
+            new Type('object'),
+            new Type('object'),
+        );
+
+        self::assertNull($transformer);
+    }
+
+    public function testSourceIsEnum(): void
+    {
+        $transformer = $this->makeTransformer(
+            new Type('object', class: UnitAddressType::class),
+            new Type('string'),
+        );
+
+        self::assertNull($transformer);
+
+        $transformer = $this->makeTransformer(
+            new Type('object', class: AddressType::class),
+            new Type('string'),
+        );
+
+        self::assertNotNull($transformer);
+        self::assertInstanceOf(SourceEnumTransformer::class, $transformer);
+    }
+
+    public function testTargetIsEnum(): void
+    {
+        $transformer = $this->makeTransformer(
+            new Type('string'),
+            new Type('object', class: UnitAddressType::class),
+        );
+
+        self::assertNull($transformer);
+
+        $transformer = $this->makeTransformer(
+            new Type('string'),
+            new Type('object', class: AddressType::class),
+        );
+
+        self::assertNotNull($transformer);
+        self::assertInstanceOf(TargetEnumTransformer::class, $transformer);
+
+    }
+
+    public function testGetCopyTransformer(): void
+    {
+        $transformer = $this->makeTransformer(
+            new Type('object', false, UnitAddressType::class),
+            new Type('object', false, AddressType::class),
+        );
+
+        self::assertNotNull($transformer);
+        self::assertInstanceOf(CopyTransformer::class, $transformer);
+    }
+
+    private function makeTransformer(Type $source, Type $target): ?TransformerInterface
+    {
+        $factory = new EnumTransformerFactory();
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        return $factory->getTransformer([$source], [$target], $mapperMetadata);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Transformer/MultipleTransformerFactoryTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Transformer/MultipleTransformerFactoryTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Transformer;
+
+use Symfony\Component\AutoMapper\MapperMetadata;
+use Symfony\Component\AutoMapper\Transformer\BuiltinTransformer;
+use Symfony\Component\AutoMapper\Transformer\BuiltinTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\ChainTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\MultipleTransformer;
+use Symfony\Component\AutoMapper\Transformer\MultipleTransformerFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class MultipleTransformerFactoryTest extends TestCase
+{
+    public function testGetTransformer()
+    {
+        $chainFactory = new ChainTransformerFactory();
+        $factory = new MultipleTransformerFactory($chainFactory);
+
+        $chainFactory->addTransformerFactory($factory);
+        $chainFactory->addTransformerFactory(new BuiltinTransformerFactory());
+
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $transformer = $factory->getTransformer([new Type('string'), new Type('int')], [], $mapperMetadata);
+
+        self::assertNotNull($transformer);
+        self::assertInstanceOf(MultipleTransformer::class, $transformer);
+
+        $transformer = $factory->getTransformer([new Type('string'), new Type('object')], [], $mapperMetadata);
+
+        self::assertNotNull($transformer);
+        self::assertInstanceOf(BuiltinTransformer::class, $transformer);
+    }
+
+    public function testNoTransformerIfNoSubTransformer()
+    {
+        $chainFactory = new ChainTransformerFactory();
+        $factory = new MultipleTransformerFactory();
+        $factory->setChainTransformerFactory($chainFactory);
+
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $transformer = $factory->getTransformer([new Type('string'), new Type('int')], [], $mapperMetadata);
+
+        self::assertNull($transformer);
+    }
+
+    public function testNoTransformer()
+    {
+        $chainFactory = new ChainTransformerFactory();
+        $factory = new MultipleTransformerFactory($chainFactory);
+
+        $chainFactory->addTransformerFactory($factory);
+        $chainFactory->addTransformerFactory(new BuiltinTransformerFactory());
+
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $transformer = $factory->getTransformer(null, null, $mapperMetadata);
+
+        self::assertNull($transformer);
+
+        $transformer = $factory->getTransformer([], null, $mapperMetadata);
+
+        self::assertNull($transformer);
+
+        $transformer = $factory->getTransformer([new Type('string')], null, $mapperMetadata);
+
+        self::assertNull($transformer);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Transformer/MultipleTransformerTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Transformer/MultipleTransformerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Transformer;
+
+use Symfony\Component\AutoMapper\Transformer\BuiltinTransformer;
+use Symfony\Component\AutoMapper\Transformer\MultipleTransformer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class MultipleTransformerTest extends TestCase
+{
+    use EvalTransformerTrait;
+
+    public function testMultipleTransformer()
+    {
+        $transformer = new MultipleTransformer([
+            [
+                'transformer' => new BuiltinTransformer(new Type('string'), [new Type('int')]),
+                'type' => new Type('string'),
+            ],
+            [
+                'transformer' => new BuiltinTransformer(new Type('int'), [new Type('string')]),
+                'type' => new Type('int'),
+            ],
+        ]);
+
+        $output = $this->evalTransformer($transformer, '12');
+
+        self::assertSame(12, $output);
+
+        $output = $this->evalTransformer($transformer, 12);
+
+        self::assertSame('12', $output);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Transformer/NullableTransformerFactoryTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Transformer/NullableTransformerFactoryTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Transformer;
+
+use Symfony\Component\AutoMapper\MapperMetadata;
+use Symfony\Component\AutoMapper\Transformer\BuiltinTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\ChainTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\NullableTransformer;
+use Symfony\Component\AutoMapper\Transformer\NullableTransformerFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class NullableTransformerFactoryTest extends TestCase
+{
+    private \ReflectionProperty $isTargetNullableProperty;
+
+    protected function setUp(): void
+    {
+        $this->isTargetNullableProperty = (new \ReflectionClass(NullableTransformer::class))->getProperty('isTargetNullable');
+        $this->isTargetNullableProperty->setAccessible(true);
+    }
+
+    public function testGetTransformer(): void
+    {
+        $chainFactory = new ChainTransformerFactory();
+        $factory = new NullableTransformerFactory($chainFactory);
+
+        $chainFactory->addTransformerFactory($factory);
+        $chainFactory->addTransformerFactory(new BuiltinTransformerFactory());
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $transformer = $factory->getTransformer([new Type('string', true)], [new Type('string')], $mapperMetadata);
+
+        self::assertNotNull($transformer);
+        self::assertInstanceOf(NullableTransformer::class, $transformer);
+        self::assertFalse($this->isTargetNullableProperty->getValue($transformer));
+
+        $transformer = $factory->getTransformer([new Type('string', true)], [new Type('string', true)], $mapperMetadata);
+
+        self::assertNotNull($transformer);
+        self::assertInstanceOf(NullableTransformer::class, $transformer);
+        self::assertTrue($this->isTargetNullableProperty->getValue($transformer));
+
+        $transformer = $factory->getTransformer([new Type('string', true)], [new Type('string'), new Type('int', true)], $mapperMetadata);
+
+        self::assertNotNull($transformer);
+        self::assertInstanceOf(NullableTransformer::class, $transformer);
+        self::assertTrue($this->isTargetNullableProperty->getValue($transformer));
+
+        $transformer = $factory->getTransformer([new Type('string', true)], [new Type('string'), new Type('int')], $mapperMetadata);
+
+        self::assertNotNull($transformer);
+        self::assertInstanceOf(NullableTransformer::class, $transformer);
+        self::assertFalse($this->isTargetNullableProperty->getValue($transformer));
+    }
+
+    public function testNullTransformerIfSourceTypeNotNullable(): void
+    {
+        $chainFactory = new ChainTransformerFactory();
+        $factory = new NullableTransformerFactory($chainFactory);
+
+        $chainFactory->addTransformerFactory($factory);
+        $chainFactory->addTransformerFactory(new BuiltinTransformerFactory());
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $transformer = $factory->getTransformer([new Type('string')], [new Type('string')], $mapperMetadata);
+
+        self::assertNull($transformer);
+    }
+
+    public function testNullTransformerIfMultipleSource(): void
+    {
+        $chainFactory = new ChainTransformerFactory();
+        $factory = new NullableTransformerFactory($chainFactory);
+
+        $chainFactory->addTransformerFactory($factory);
+        $chainFactory->addTransformerFactory(new BuiltinTransformerFactory());
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $transformer = $factory->getTransformer([new Type('string', true), new Type('string')], [new Type('string')], $mapperMetadata);
+
+        self::assertNull($transformer);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Transformer/NullableTransformerTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Transformer/NullableTransformerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Transformer;
+
+use Symfony\Component\AutoMapper\Transformer\BuiltinTransformer;
+use Symfony\Component\AutoMapper\Transformer\NullableTransformer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class NullableTransformerTest extends TestCase
+{
+    use EvalTransformerTrait;
+
+    public function testNullTransformerTargetNullable()
+    {
+        $transformer = new NullableTransformer(new BuiltinTransformer(new Type('string'), [new Type('string', true)]), true);
+
+        $output = $this->evalTransformer($transformer, 'foo');
+
+        self::assertSame('foo', $output);
+
+        $output = $this->evalTransformer($transformer, null);
+
+        self::assertNull($output);
+    }
+
+    public function testNullTransformerTargetNotNullable()
+    {
+        $transformer = new NullableTransformer(new BuiltinTransformer(new Type('string'), [new Type('string')]), false);
+
+        $output = $this->evalTransformer($transformer, 'foo');
+
+        self::assertSame('foo', $output);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Transformer/ObjectTransformerFactoryTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Transformer/ObjectTransformerFactoryTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Transformer;
+
+use Symfony\Component\AutoMapper\AutoMapperRegistryInterface;
+use Symfony\Component\AutoMapper\MapperMetadata;
+use Symfony\Component\AutoMapper\Transformer\ObjectTransformer;
+use Symfony\Component\AutoMapper\Transformer\ObjectTransformerFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class ObjectTransformerFactoryTest extends TestCase
+{
+    public function testGetTransformer(): void
+    {
+        $autoMapperRegistry = $this->getMockBuilder(AutoMapperRegistryInterface::class)->getMock();
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+        $factory = new ObjectTransformerFactory($autoMapperRegistry);
+
+        $autoMapperRegistry
+            ->expects($this->any())
+            ->method('hasMapper')
+            ->willReturn(true)
+        ;
+
+        $transformer = $factory->getTransformer([new Type('object', false, \stdClass::class)], [new Type('object', false, \stdClass::class)], $mapperMetadata);
+
+        self::assertNotNull($transformer);
+        self::assertInstanceOf(ObjectTransformer::class, $transformer);
+
+        $transformer = $factory->getTransformer([new Type('array')], [new Type('object', false, \stdClass::class)], $mapperMetadata);
+
+        self::assertNotNull($transformer);
+        self::assertInstanceOf(ObjectTransformer::class, $transformer);
+
+        $transformer = $factory->getTransformer([new Type('object', false, \stdClass::class)], [new Type('array')], $mapperMetadata);
+
+        self::assertNotNull($transformer);
+        self::assertInstanceOf(ObjectTransformer::class, $transformer);
+    }
+
+    public function testNoTransformer(): void
+    {
+        $autoMapperRegistry = $this->getMockBuilder(AutoMapperRegistryInterface::class)->getMock();
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+        $factory = new ObjectTransformerFactory($autoMapperRegistry);
+
+        $transformer = $factory->getTransformer([], [], $mapperMetadata);
+
+        self::assertNull($transformer);
+
+        $transformer = $factory->getTransformer([new Type('object')], [], $mapperMetadata);
+
+        self::assertNull($transformer);
+
+        $transformer = $factory->getTransformer([], [new Type('object')], $mapperMetadata);
+
+        self::assertNull($transformer);
+
+        $transformer = $factory->getTransformer([new Type('object'), new Type('object')], [new Type('object')], $mapperMetadata);
+
+        self::assertNull($transformer);
+
+        $transformer = $factory->getTransformer([new Type('object')], [new Type('object'), new Type('object')], $mapperMetadata);
+
+        self::assertNull($transformer);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Transformer/ObjectTransformerTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Transformer/ObjectTransformerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Transformer;
+
+use Symfony\Component\AutoMapper\Transformer\ObjectTransformer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\AutoMapper\Tests\Fixtures;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class ObjectTransformerTest extends TestCase
+{
+    use EvalTransformerTrait;
+
+    public function testObjectTransformer()
+    {
+        $transformer = new ObjectTransformer(new Type('object', false, Foo::class), new Type('object', false, Foo::class));
+
+        $function = $this->createTransformerFunction($transformer);
+        $class = new class() {
+            public $mappers;
+
+            public function __construct()
+            {
+                $this->mappers['Mapper_' . Foo::class . '_' . Foo::class] = new class() {
+                    public function map()
+                    {
+                        return new Foo();
+                    }
+                };
+            }
+        };
+
+        $transform = \Closure::bind($function, $class);
+        $output = $transform(new Foo());
+
+        self::assertNotNull($output);
+        self::assertInstanceOf(Foo::class, $output);
+    }
+}
+
+class Foo
+{
+    public $bar;
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Transformer/StringToDateTimeTransformerTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Transformer/StringToDateTimeTransformerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Transformer;
+
+use Symfony\Component\AutoMapper\Transformer\StringToDateTimeTransformer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class StringToDateTimeTransformerTest extends TestCase
+{
+    use EvalTransformerTrait;
+
+    public function testDateTimeTransformer()
+    {
+        $transformer = new StringToDateTimeTransformer(\DateTime::class);
+
+        $date = new \DateTime();
+        $output = $this->evalTransformer($transformer, $date->format(\DateTime::RFC3339));
+
+        self::assertInstanceOf(\DateTime::class, $output);
+        self::assertSame($date->format(\DateTime::RFC3339), $output->format(\DateTime::RFC3339));
+    }
+
+    public function testDateTimeTransformerCustomFormat()
+    {
+        $transformer = new StringToDateTimeTransformer(\DateTime::class, \DateTime::COOKIE);
+
+        $date = new \DateTime();
+        $output = $this->evalTransformer($transformer, $date->format(\DateTime::COOKIE));
+
+        self::assertInstanceOf(\DateTime::class, $output);
+        self::assertSame($date->format(\DateTime::RFC3339), $output->format(\DateTime::RFC3339));
+    }
+
+    public function testDateTimeTransformerImmutable()
+    {
+        $transformer = new StringToDateTimeTransformer(\DateTimeImmutable::class, \DateTime::COOKIE);
+
+        $date = new \DateTime();
+        $output = $this->evalTransformer($transformer, $date->format(\DateTime::COOKIE));
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $output);
+    }
+
+    public function testDateTimeTransformerInterface()
+    {
+        $transformer = new StringToDateTimeTransformer(\DateTimeInterface::class);
+
+        $date = new \DateTime();
+        $output = $this->evalTransformer($transformer, $date->format(\DateTime::RFC3339));
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $output);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Transformer/SymfonyUidTransformerFactoryTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Transformer/SymfonyUidTransformerFactoryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Transformer;
+
+use Symfony\Component\AutoMapper\MapperMetadata;
+use Symfony\Component\AutoMapper\Transformer\SymfonyUidCopyTransformer;
+use Symfony\Component\AutoMapper\Transformer\SymfonyUidTransformerFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Uid\Ulid;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class SymfonyUidTransformerFactoryTest extends TestCase
+{
+    public function testNoTransformer(): void
+    {
+        $factory = new SymfonyUidTransformerFactory();
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $transformer = $factory->getTransformer([new Type('object', false, null)], [new Type('object', false, null)], $mapperMetadata);
+
+        self::assertNull($transformer);
+    }
+
+    public function testGetUlidCopyTransformer(): void
+    {
+        $factory = new SymfonyUidTransformerFactory();
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $transformer = $factory->getTransformer(
+            [new Type('object', false, Ulid::class)],
+            [new Type('object', false, Ulid::class)],
+            $mapperMetadata
+        );
+
+        self::assertNotNull($transformer);
+        self::assertInstanceOf(SymfonyUidCopyTransformer::class, $transformer);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Tests/Transformer/UniqueTypeTransformerFactoryTest.php
+++ b/src/Symfony/Component/AutoMapper/Tests/Transformer/UniqueTypeTransformerFactoryTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Symfony\Component\AutoMapper\Tests\Transformer;
+
+use Symfony\Component\AutoMapper\MapperMetadata;
+use Symfony\Component\AutoMapper\Transformer\BuiltinTransformer;
+use Symfony\Component\AutoMapper\Transformer\BuiltinTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\ChainTransformerFactory;
+use Symfony\Component\AutoMapper\Transformer\UniqueTypeTransformerFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class UniqueTypeTransformerFactoryTest extends TestCase
+{
+    public function testGetTransformer(): void
+    {
+        $chainFactory = new ChainTransformerFactory();
+        $factory = new UniqueTypeTransformerFactory($chainFactory);
+
+        $chainFactory->addTransformerFactory($factory);
+        $chainFactory->addTransformerFactory(new BuiltinTransformerFactory());
+
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $transformer = $factory->getTransformer([new Type('string')], [new Type('string'), new Type('string')], $mapperMetadata);
+
+        self::assertNotNull($transformer);
+        self::assertInstanceOf(BuiltinTransformer::class, $transformer);
+    }
+
+    public function testNullTransformer(): void
+    {
+        $chainFactory = new ChainTransformerFactory();
+        $factory = new UniqueTypeTransformerFactory($chainFactory);
+
+        $chainFactory->addTransformerFactory($factory);
+        $chainFactory->addTransformerFactory(new BuiltinTransformerFactory());
+
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $transformer = $factory->getTransformer(null, [], $mapperMetadata);
+
+        self::assertNull($transformer);
+
+        $transformer = $factory->getTransformer([], [], $mapperMetadata);
+
+        self::assertNull($transformer);
+
+        $transformer = $factory->getTransformer([new Type('string')], [], $mapperMetadata);
+
+        self::assertNull($transformer);
+
+        $transformer = $factory->getTransformer([new Type('string'), new Type('string')], [], $mapperMetadata);
+
+        self::assertNull($transformer);
+
+        $transformer = $factory->getTransformer([new Type('string')], [new Type('string')], $mapperMetadata);
+
+        self::assertNull($transformer);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/AbstractUniqueTypeTransformerFactory.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/AbstractUniqueTypeTransformerFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\MapperMetadataInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Abstract transformer which is used by transformer needing transforming only from one single type to one single type.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+abstract class AbstractUniqueTypeTransformerFactory implements TransformerFactoryInterface
+{
+    public function getTransformer(?array $sourceTypes, ?array $targetTypes, MapperMetadataInterface $mapperMetadata): ?TransformerInterface
+    {
+        $nbSourceTypes = $sourceTypes ? \count($sourceTypes) : 0;
+        $nbTargetTypes = $targetTypes ? \count($targetTypes) : 0;
+
+        if (0 === $nbSourceTypes || $nbSourceTypes > 1 || !$sourceTypes[0] instanceof Type) {
+            return null;
+        }
+
+        if (0 === $nbTargetTypes || $nbTargetTypes > 1 || !$targetTypes[0] instanceof Type) {
+            return null;
+        }
+
+        return $this->createTransformer($sourceTypes[0], $targetTypes[0], $mapperMetadata);
+    }
+
+    abstract protected function createTransformer(Type $sourceType, Type $targetType, MapperMetadataInterface $mapperMetadata): ?TransformerInterface;
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/ArrayTransformer.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/ArrayTransformer.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use PhpParser\Node\Expr;
+
+/**
+ * Transformer array decorator.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class ArrayTransformer extends AbstractArrayTransformer
+{
+    protected function getAssignExpr(Expr $valuesVar, Expr $outputVar, Expr $loopKeyVar, bool $assignByRef): Expr
+    {
+        if ($assignByRef) {
+            return new Expr\AssignRef(new Expr\ArrayDimFetch($valuesVar), $outputVar);
+        }
+
+        return new Expr\Assign(new Expr\ArrayDimFetch($valuesVar), $outputVar);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/ArrayTransformerFactory.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/ArrayTransformerFactory.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\MapperMetadataInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Create a decorated transformer to handle array type.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class ArrayTransformerFactory extends AbstractUniqueTypeTransformerFactory implements PrioritizedTransformerFactoryInterface, ChainTransformerFactoryAwareInterface
+{
+    use ChainTransformerFactoryAwareTrait;
+
+    protected function createTransformer(Type $sourceType, Type $targetType, MapperMetadataInterface $mapperMetadata): ?TransformerInterface
+    {
+        if (!$sourceType->isCollection()) {
+            return null;
+        }
+
+        if (!$targetType->isCollection()) {
+            return null;
+        }
+
+        if ([] === $sourceType->getCollectionValueTypes() || [] === $targetType->getCollectionValueTypes()) {
+            return new CopyTransformer();
+        }
+
+        $subItemTransformer = $this->chainTransformerFactory->getTransformer($sourceType->getCollectionValueTypes(), $targetType->getCollectionValueTypes(), $mapperMetadata);
+
+        if (null !== $subItemTransformer) {
+            $sourceCollectionKeyTypes = $sourceType->getCollectionKeyTypes();
+            $sourceCollectionKeyType = $sourceCollectionKeyTypes[0] ?? null;
+
+            if ($sourceCollectionKeyType instanceof Type && Type::BUILTIN_TYPE_INT !== $sourceCollectionKeyType->getBuiltinType()) {
+                return new DictionaryTransformer($subItemTransformer);
+            }
+
+            return new ArrayTransformer($subItemTransformer);
+        }
+
+        return null;
+    }
+
+    public function getPriority(): int
+    {
+        return 4;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/AssignedByReferenceTransformerInterface.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/AssignedByReferenceTransformerInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+interface AssignedByReferenceTransformerInterface
+{
+    /**
+     * Should the resulting output be assigned by ref.
+     */
+    public function assignByRef(): bool;
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/BuiltinTransformer.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/BuiltinTransformer.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\Generator\UniqueVariableScope;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Cast;
+use PhpParser\Node\Name;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Built in transformer to handle PHP scalar types.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class BuiltinTransformer implements TransformerInterface
+{
+    private const CAST_MAPPING = [
+        Type::BUILTIN_TYPE_BOOL => [
+            Type::BUILTIN_TYPE_INT => Cast\Int_::class,
+            Type::BUILTIN_TYPE_STRING => Cast\String_::class,
+            Type::BUILTIN_TYPE_FLOAT => Cast\Double::class,
+            Type::BUILTIN_TYPE_ARRAY => 'toArray',
+            Type::BUILTIN_TYPE_ITERABLE => 'toArray',
+        ],
+        Type::BUILTIN_TYPE_FLOAT => [
+            Type::BUILTIN_TYPE_STRING => Cast\String_::class,
+            Type::BUILTIN_TYPE_INT => Cast\Int_::class,
+            Type::BUILTIN_TYPE_BOOL => Cast\Bool_::class,
+            Type::BUILTIN_TYPE_ARRAY => 'toArray',
+            Type::BUILTIN_TYPE_ITERABLE => 'toArray',
+        ],
+        Type::BUILTIN_TYPE_INT => [
+            Type::BUILTIN_TYPE_FLOAT => Cast\Double::class,
+            Type::BUILTIN_TYPE_STRING => Cast\String_::class,
+            Type::BUILTIN_TYPE_BOOL => Cast\Bool_::class,
+            Type::BUILTIN_TYPE_ARRAY => 'toArray',
+            Type::BUILTIN_TYPE_ITERABLE => 'toArray',
+        ],
+        Type::BUILTIN_TYPE_ITERABLE => [
+            Type::BUILTIN_TYPE_ARRAY => 'fromIteratorToArray',
+        ],
+        Type::BUILTIN_TYPE_ARRAY => [],
+        Type::BUILTIN_TYPE_STRING => [
+            Type::BUILTIN_TYPE_ARRAY => 'toArray',
+            Type::BUILTIN_TYPE_ITERABLE => 'toArray',
+            Type::BUILTIN_TYPE_FLOAT => Cast\Double::class,
+            Type::BUILTIN_TYPE_INT => Cast\Int_::class,
+            Type::BUILTIN_TYPE_BOOL => Cast\Bool_::class,
+        ],
+        Type::BUILTIN_TYPE_CALLABLE => [],
+        Type::BUILTIN_TYPE_RESOURCE => [],
+    ];
+
+    public function __construct(
+        private readonly Type $sourceType,
+        /** @var Type[] $targetTypes */
+        private readonly array $targetTypes
+    ) {
+    }
+
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        $targetTypes = array_map(function (Type $type) {
+            return $type->getBuiltinType();
+        }, $this->targetTypes);
+
+        // Source type is in target => no cast
+        if (\in_array($this->sourceType->getBuiltinType(), $targetTypes, true)) {
+            return [$input, []];
+        }
+
+        // Cast needed
+        foreach (self::CAST_MAPPING[$this->sourceType->getBuiltinType()] as $castType => $castMethod) {
+            if (\in_array($castType, $targetTypes, true)) {
+                if (method_exists($this, $castMethod)) {
+                    return [$this->$castMethod($input), []];
+                }
+
+                return [new $castMethod($input), []];
+            }
+        }
+
+        return [$input, []];
+    }
+
+    private function toArray(Expr $input): Expr\Array_
+    {
+        return new Expr\Array_([new Expr\ArrayItem($input)]);
+    }
+
+    private function fromIteratorToArray(Expr $input): Expr\FuncCall
+    {
+        return new Expr\FuncCall(new Name('iterator_to_array'), [
+            new Arg($input),
+        ]);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/BuiltinTransformerFactory.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/BuiltinTransformerFactory.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\MapperMetadataInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Create a decorated transformer to handle builtin types.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class BuiltinTransformerFactory implements TransformerFactoryInterface, PrioritizedTransformerFactoryInterface
+{
+    private const BUILTIN = [
+        Type::BUILTIN_TYPE_BOOL,
+        Type::BUILTIN_TYPE_CALLABLE,
+        Type::BUILTIN_TYPE_FLOAT,
+        Type::BUILTIN_TYPE_INT,
+        Type::BUILTIN_TYPE_ITERABLE,
+        Type::BUILTIN_TYPE_NULL,
+        Type::BUILTIN_TYPE_RESOURCE,
+        Type::BUILTIN_TYPE_STRING,
+    ];
+
+    public function getTransformer(?array $sourceTypes, ?array $targetTypes, MapperMetadataInterface $mapperMetadata): ?TransformerInterface
+    {
+        $nbSourceTypes = $sourceTypes ? \count($sourceTypes) : 0;
+
+        if (null === $sourceTypes || 0 === $nbSourceTypes || $nbSourceTypes > 1 || !$sourceTypes[0] instanceof Type) {
+            return null;
+        }
+
+        $propertyType = $sourceTypes[0];
+
+        if (null !== $targetTypes && \in_array($propertyType->getBuiltinType(), self::BUILTIN, true)) {
+            return new BuiltinTransformer($propertyType, $targetTypes);
+        }
+
+        return null;
+    }
+
+    public function getPriority(): int
+    {
+        return 8;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/CallbackTransformer.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/CallbackTransformer.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\Generator\UniqueVariableScope;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Scalar;
+
+/**
+ * Handle custom callback transformation.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class CallbackTransformer implements TransformerInterface
+{
+    public function __construct(
+        private readonly string $callbackName
+    ) {
+    }
+
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        /*
+         * $output = $this->callbacks[$callbackName]($input);
+         */
+
+        $arguments = [new Arg($input), new Arg($target)];
+
+        return [new Expr\FuncCall(
+            new Expr\ArrayDimFetch(new Expr\PropertyFetch(new Expr\Variable('this'), 'callbacks'), new Scalar\String_($this->callbackName)), $arguments),
+            [],
+        ];
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/ChainTransformerFactory.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/ChainTransformerFactory.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\MapperMetadataInterface;
+
+/**
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class ChainTransformerFactory implements TransformerFactoryInterface
+{
+    /** @var array<int, TransformerFactoryInterface[]> $factories */
+    private array $factories = [];
+
+    /** @var TransformerFactoryInterface[]|null */
+    private ?array $sorted = null;
+
+    public function __construct(
+        /** @var array<int, TransformerFactoryInterface[]> $factories */
+        array $factories = [],
+    ) {
+        if (\count($factories) > 0) {
+            foreach ($factories as $priority => $factory) {
+                $this->addTransformerFactory($factory, $priority);
+            }
+        }
+    }
+
+    /**
+     * Biggest priority is MultipleTransformerFactory with 128, so default priority will be bigger in order to
+     * be used before it, 256 should be enough.
+     */
+    public function addTransformerFactory(TransformerFactoryInterface $transformerFactory, int $priority = 256): void
+    {
+        if ($this->hasTransformerFactory($transformerFactory)) {
+            return;
+        }
+
+        $this->sorted = null;
+
+        if ($transformerFactory instanceof ChainTransformerFactoryAwareInterface) {
+            $transformerFactory->setChainTransformerFactory($this);
+        }
+        if ($transformerFactory instanceof PrioritizedTransformerFactoryInterface) {
+            $priority = $transformerFactory->getPriority();
+        }
+
+        if (!\array_key_exists($priority, $this->factories)) {
+            $this->factories[$priority] = [];
+        }
+        $this->factories[$priority][] = $transformerFactory;
+    }
+
+    public function hasTransformerFactory(TransformerFactoryInterface $transformerFactory): bool
+    {
+        $this->sortFactories();
+
+        $transformerFactoryClass = $transformerFactory::class;
+        foreach ($this->sorted as $factory) {
+            if (is_a($factory, $transformerFactoryClass)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function getTransformer(?array $sourceTypes, ?array $targetTypes, MapperMetadataInterface $mapperMetadata): ?TransformerInterface
+    {
+        $this->sortFactories();
+
+        foreach ($this->sorted as $factory) {
+            $transformer = $factory->getTransformer($sourceTypes, $targetTypes, $mapperMetadata);
+
+            if (null !== $transformer) {
+                return $transformer;
+            }
+        }
+
+        return null;
+    }
+
+    private function sortFactories(): void
+    {
+        if (null === $this->sorted) {
+            $this->sorted = [];
+            krsort($this->factories);
+
+            foreach ($this->factories as $prioritisedFactories) {
+                foreach ($prioritisedFactories as $factory) {
+                    $this->sorted[] = $factory;
+                }
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/ChainTransformerFactoryAwareInterface.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/ChainTransformerFactoryAwareInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+/**
+ * Transformer factory that needs to be aware of the chain transformer factory
+ *
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+interface ChainTransformerFactoryAwareInterface
+{
+    public function setChainTransformerFactory(ChainTransformerFactory $chainTransformerFactory): void;
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/ChainTransformerFactoryAwareTrait.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/ChainTransformerFactoryAwareTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+/**
+ * Transformer factory that needs to be aware of the chain transformer factory
+ *
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+trait ChainTransformerFactoryAwareTrait
+{
+    protected ChainTransformerFactory $chainTransformerFactory;
+
+    public function setChainTransformerFactory(ChainTransformerFactory $chainTransformerFactory): void
+    {
+        $this->chainTransformerFactory = $chainTransformerFactory;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/CopyTransformer.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/CopyTransformer.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\Generator\UniqueVariableScope;
+use PhpParser\Node\Expr;
+
+/**
+ * Does not do any transformation, output = input.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class CopyTransformer implements TransformerInterface
+{
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        return [$input, []];
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/DateTimeImmutableToMutableTransformer.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/DateTimeImmutableToMutableTransformer.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\Generator\UniqueVariableScope;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+
+/**
+ * Transform DateTimeImmutable to DateTime.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class DateTimeImmutableToMutableTransformer implements TransformerInterface
+{
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        return [
+            new Expr\StaticCall(new Name\FullyQualified(\DateTime::class), 'createFromFormat', [
+                new Arg(new String_(\DateTimeInterface::RFC3339)),
+                new Arg(new Expr\MethodCall($input, 'format', [
+                    new Arg(new String_(\DateTimeInterface::RFC3339)),
+                ])),
+            ]),
+            [],
+        ];
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/DateTimeMutableToImmutableTransformer.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/DateTimeMutableToImmutableTransformer.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\Generator\UniqueVariableScope;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+
+/**
+ * Transform DateTime to DateTimeImmutable.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class DateTimeMutableToImmutableTransformer implements TransformerInterface
+{
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        return [
+            new Expr\StaticCall(new Name\FullyQualified(\DateTimeImmutable::class), 'createFromMutable', [
+                new Arg($input),
+            ]),
+            [],
+        ];
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/DateTimeToStringTransformer.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/DateTimeToStringTransformer.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\Generator\UniqueVariableScope;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Scalar\String_;
+
+/**
+ * Transform a \DateTimeInterface object to a string.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class DateTimeToStringTransformer implements TransformerInterface
+{
+    public function __construct(
+        private readonly string $format = \DateTimeInterface::RFC3339
+    ) {
+    }
+
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        return [new Expr\MethodCall($input, 'format', [
+            new Arg(new String_($this->format)),
+        ]), []];
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/DateTimeTransformerFactory.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/DateTimeTransformerFactory.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\MapperMetadataInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class DateTimeTransformerFactory extends AbstractUniqueTypeTransformerFactory implements PrioritizedTransformerFactoryInterface
+{
+    protected function createTransformer(Type $sourceType, Type $targetType, MapperMetadataInterface $mapperMetadata): ?TransformerInterface
+    {
+        $isSourceDate = $this->isDateTimeType($sourceType);
+        $isTargetDate = $this->isDateTimeType($targetType);
+
+        if ($isSourceDate && $isTargetDate) {
+            return $this->createTransformerForSourceAndTarget($sourceType, $targetType);
+        }
+
+        if ($isSourceDate) {
+            return $this->createTransformerForSource($targetType, $mapperMetadata);
+        }
+
+        if ($isTargetDate) {
+            return $this->createTransformerForTarget($sourceType, $targetType, $mapperMetadata);
+        }
+
+        return null;
+    }
+
+    protected function createTransformerForSourceAndTarget(Type $sourceType, Type $targetType): ?TransformerInterface
+    {
+        $isSourceMutable = $this->isDateTimeMutable($sourceType);
+        $isTargetMutable = $this->isDateTimeMutable($targetType);
+
+        if ($isSourceMutable === $isTargetMutable) {
+            return new CopyTransformer();
+        }
+
+        if ($isSourceMutable) {
+            return new DateTimeMutableToImmutableTransformer();
+        }
+
+        return new DateTimeImmutableToMutableTransformer();
+    }
+
+    protected function createTransformerForSource(Type $targetType, MapperMetadataInterface $mapperMetadata): ?TransformerInterface
+    {
+        if (Type::BUILTIN_TYPE_STRING === $targetType->getBuiltinType()) {
+            return new DateTimeToStringTransformer($mapperMetadata->getDateTimeFormat());
+        }
+
+        return null;
+    }
+
+    protected function createTransformerForTarget(Type $sourceType, Type $targetType, MapperMetadataInterface $mapperMetadata): ?TransformerInterface
+    {
+        if (Type::BUILTIN_TYPE_STRING === $sourceType->getBuiltinType()) {
+            return new StringToDateTimeTransformer($this->getClassName($targetType), $mapperMetadata->getDateTimeFormat());
+        }
+
+        return null;
+    }
+
+    private function isDateTimeType(Type $type): bool
+    {
+        if (Type::BUILTIN_TYPE_OBJECT !== $type->getBuiltinType()) {
+            return false;
+        }
+
+        if (\DateTimeInterface::class !== $type->getClassName() && !is_subclass_of($type->getClassName(), \DateTimeInterface::class)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function getClassName(Type $type): string
+    {
+        if (null === $type->getClassName() && \DateTimeInterface::class !== $type->getClassName()) {
+            return \DateTimeImmutable::class;
+        }
+
+        return $type->getClassName();
+    }
+
+    private function isDateTimeMutable(Type $type): bool
+    {
+        if (\DateTime::class !== $type->getClassName() && !is_subclass_of($type->getClassName(), \DateTime::class)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function getPriority(): int
+    {
+        return 16;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/DependentTransformerInterface.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/DependentTransformerInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+interface DependentTransformerInterface
+{
+    /**
+     * Get dependencies for this transformer.
+     *
+     * @return MapperDependency[]
+     */
+    public function getDependencies(): array;
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/DictionaryTransformer.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/DictionaryTransformer.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use PhpParser\Node\Expr;
+
+/**
+ * Transformer dictionary decorator.
+ *
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class DictionaryTransformer extends AbstractArrayTransformer
+{
+    protected function getAssignExpr(Expr $valuesVar, Expr $outputVar, Expr $loopKeyVar, bool $assignByRef): Expr
+    {
+        if ($assignByRef) {
+            return new Expr\AssignRef(new Expr\ArrayDimFetch($valuesVar, $loopKeyVar), $outputVar);
+        }
+
+        return new Expr\Assign(new Expr\ArrayDimFetch($valuesVar, $loopKeyVar), $outputVar);
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/EnumTransformerFactory.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/EnumTransformerFactory.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\MapperMetadataInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Create a decorated transformer to handle enum type.
+ *
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class EnumTransformerFactory extends AbstractUniqueTypeTransformerFactory implements PrioritizedTransformerFactoryInterface
+{
+    protected function createTransformer(Type $sourceType, Type $targetType, MapperMetadataInterface $mapperMetadata): ?TransformerInterface
+    {
+        // source is enum, target isn't
+        if ($this->isEnumType($sourceType, true) && !$this->isEnumType($targetType)) {
+            return new SourceEnumTransformer();
+        }
+
+        // target is enum, source isn't
+        if (!$this->isEnumType($sourceType) && $this->isEnumType($targetType, true)) {
+            return new TargetEnumTransformer($targetType->getClassName());
+        }
+
+        // both source & target are enums
+        if ($this->isEnumType($sourceType) && $this->isEnumType($targetType)) {
+            return new CopyTransformer();
+        }
+
+        return null;
+    }
+
+    private function isEnumType(Type $type, bool $backed = false): bool
+    {
+        if (Type::BUILTIN_TYPE_OBJECT !== $type->getBuiltinType()) {
+            return false;
+        }
+
+        if (!is_subclass_of($type->getClassName(), \UnitEnum::class)) {
+            return false;
+        }
+
+        if ($backed && !is_subclass_of($type->getClassName(), \BackedEnum::class)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function getPriority(): int
+    {
+        return 2;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/MapperDependency.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/MapperDependency.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+/**
+ * Represent a dependency on a mapper (allow to inject sub mappers).
+ *
+ * @internal
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class MapperDependency
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $source,
+        public readonly string $target,
+    ) {
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/MultipleTransformer.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/MultipleTransformer.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\Generator\UniqueVariableScope;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Multiple transformer decorator.
+ *
+ * Decorate transformers with condition to handle property with multiples source types
+ * It will always use the first target type possible for transformation
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class MultipleTransformer implements TransformerInterface, DependentTransformerInterface
+{
+    private const CONDITION_MAPPING = [
+        Type::BUILTIN_TYPE_BOOL => 'is_bool',
+        Type::BUILTIN_TYPE_INT => 'is_int',
+        Type::BUILTIN_TYPE_FLOAT => 'is_float',
+        Type::BUILTIN_TYPE_STRING => 'is_string',
+        Type::BUILTIN_TYPE_NULL => 'is_null',
+        Type::BUILTIN_TYPE_ARRAY => 'is_array',
+        Type::BUILTIN_TYPE_OBJECT => 'is_object',
+        Type::BUILTIN_TYPE_RESOURCE => 'is_resource',
+        Type::BUILTIN_TYPE_CALLABLE => 'is_callable',
+        Type::BUILTIN_TYPE_ITERABLE => 'is_iterable',
+    ];
+
+    /** @var array<array{transformer: TransformerInterface, type: Type}> */
+    private array $transformers;
+
+    public function __construct(array $transformers)
+    {
+        $this->transformers = $transformers;
+    }
+
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        $output = new Expr\Variable($uniqueVariableScope->getUniqueName('value'));
+        $statements = [
+            new Stmt\Expression(new Expr\Assign($output, $input)),
+        ];
+
+        foreach ($this->transformers as $transformerData) {
+            $transformer = $transformerData['transformer'];
+            $type = $transformerData['type'];
+
+            [$transformerOutput, $transformerStatements] = $transformer->transform($input, $target, $propertyMapping, $uniqueVariableScope);
+
+            $assignClass = ($transformer instanceof AssignedByReferenceTransformerInterface && $transformer->assignByRef()) ? Expr\AssignRef::class : Expr\Assign::class;
+            $statements[] = new Stmt\If_(
+                new Expr\FuncCall(
+                    new Name(self::CONDITION_MAPPING[$type->getBuiltinType()]),
+                    [
+                        new Arg($input),
+                    ]
+                ),
+                [
+                    'stmts' => array_merge(
+                        $transformerStatements, [
+                            new Stmt\Expression(new $assignClass($output, $transformerOutput)),
+                        ]
+                    ),
+                ]
+            );
+        }
+
+        return [$output, $statements];
+    }
+
+    public function getDependencies(): array
+    {
+        $dependencies = [];
+
+        foreach ($this->transformers as $transformerData) {
+            if ($transformerData['transformer'] instanceof DependentTransformerInterface) {
+                $dependencies = array_merge($dependencies, $transformerData['transformer']->getDependencies());
+            }
+        }
+
+        return $dependencies;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/MultipleTransformerFactory.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/MultipleTransformerFactory.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\MapperMetadataInterface;
+
+/**
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class MultipleTransformerFactory implements TransformerFactoryInterface, PrioritizedTransformerFactoryInterface, ChainTransformerFactoryAwareInterface
+{
+    use ChainTransformerFactoryAwareTrait;
+
+    public function getTransformer(?array $sourceTypes, ?array $targetTypes, MapperMetadataInterface $mapperMetadata): ?TransformerInterface
+    {
+        if (null === $sourceTypes || \count($sourceTypes) <= 1) {
+            return null;
+        }
+
+        $transformers = [];
+
+        foreach ($sourceTypes as $sourceType) {
+            $transformer = $this->chainTransformerFactory->getTransformer([$sourceType], $targetTypes, $mapperMetadata);
+
+            if (null !== $transformer) {
+                $transformers[] = [
+                    'transformer' => $transformer,
+                    'type' => $sourceType,
+                ];
+            }
+        }
+
+        if (\count($transformers) > 1) {
+            return new MultipleTransformer($transformers);
+        }
+
+        if (1 === \count($transformers)) {
+            return $transformers[0]['transformer'];
+        }
+
+        return null;
+    }
+
+    public function getPriority(): int
+    {
+        return 128;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/NullableTransformer.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/NullableTransformer.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\Generator\UniqueVariableScope;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+
+/**
+ * Transformer decorator to handle null values.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class NullableTransformer implements TransformerInterface, DependentTransformerInterface
+{
+    public function __construct(
+        private readonly TransformerInterface $itemTransformer,
+        private readonly bool $isTargetNullable
+    ) {
+    }
+
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        [$output, $itemStatements] = $this->itemTransformer->transform($input, $target, $propertyMapping, $uniqueVariableScope);
+
+        $newOutput = null;
+        $statements = [];
+        $assignClass = ($this->itemTransformer instanceof AssignedByReferenceTransformerInterface && $this->itemTransformer->assignByRef()) ? Expr\AssignRef::class : Expr\Assign::class;
+
+        if ($this->isTargetNullable) {
+            $newOutput = new Expr\Variable($uniqueVariableScope->getUniqueName('value'));
+            $statements[] = new Stmt\Expression(new Expr\Assign($newOutput, new Expr\ConstFetch(new Name('null'))));
+            $itemStatements[] = new Stmt\Expression(new $assignClass($newOutput, $output));
+        }
+
+        $statements[] = new Stmt\If_(new Expr\BinaryOp\NotIdentical(new Expr\ConstFetch(new Name('null')), $input), [
+            'stmts' => $itemStatements,
+        ]);
+
+        return [$newOutput ?? $output, $statements];
+    }
+
+    public function getDependencies(): array
+    {
+        if (!$this->itemTransformer instanceof DependentTransformerInterface) {
+            return [];
+        }
+
+        return $this->itemTransformer->getDependencies();
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/NullableTransformerFactory.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/NullableTransformerFactory.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\MapperMetadataInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class NullableTransformerFactory implements TransformerFactoryInterface, PrioritizedTransformerFactoryInterface, ChainTransformerFactoryAwareInterface
+{
+    use ChainTransformerFactoryAwareTrait;
+
+    public function getTransformer(?array $sourceTypes, ?array $targetTypes, MapperMetadataInterface $mapperMetadata): ?TransformerInterface
+    {
+        $nbSourceTypes = $sourceTypes ? \count($sourceTypes) : 0;
+
+        if (null === $sourceTypes || 0 === $nbSourceTypes || $nbSourceTypes > 1) {
+            return null;
+        }
+
+        $propertyType = $sourceTypes[0];
+
+        if (!$propertyType->isNullable()) {
+            return null;
+        }
+
+        $isTargetNullable = false;
+
+        foreach ($targetTypes as $targetType) {
+            if ($targetType->isNullable()) {
+                $isTargetNullable = true;
+
+                break;
+            }
+        }
+
+        $subTransformer = $this->chainTransformerFactory->getTransformer([new Type(
+            $propertyType->getBuiltinType(),
+            false,
+            $propertyType->getClassName(),
+            $propertyType->isCollection(),
+            $propertyType->getCollectionKeyTypes(),
+            $propertyType->getCollectionValueTypes()
+        )], $targetTypes, $mapperMetadata);
+
+        if (null === $subTransformer) {
+            return null;
+        }
+
+        // Remove nullable property here to avoid infinite loop
+        return new NullableTransformer($subTransformer, $isTargetNullable);
+    }
+
+    public function getPriority(): int
+    {
+        return 64;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/ObjectTransformer.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/ObjectTransformer.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\Generator\UniqueVariableScope;
+use Symfony\Component\AutoMapper\MapperContext;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Transform to an object which can be mapped by AutoMapper (sub mapping).
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ */
+final class ObjectTransformer implements TransformerInterface, DependentTransformerInterface, AssignedByReferenceTransformerInterface
+{
+    public function __construct(
+        private readonly Type $sourceType,
+        private readonly Type $targetType,
+    ) {
+    }
+
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        $mapperName = $this->getDependencyName();
+
+        return [new Expr\MethodCall(new Expr\ArrayDimFetch(
+            new Expr\PropertyFetch(new Expr\Variable('this'), 'mappers'),
+            new Scalar\String_($mapperName)
+        ), 'map', [
+            new Arg($input),
+            new Arg(new Expr\StaticCall(new Name\FullyQualified(MapperContext::class), 'withNewContext', [
+                new Arg(new Expr\Variable('context')),
+                new Arg(new Scalar\String_($propertyMapping->property)),
+            ])),
+        ]), []];
+    }
+
+    public function assignByRef(): bool
+    {
+        return true;
+    }
+
+    public function getDependencies(): array
+    {
+        return [new MapperDependency($this->getDependencyName(), $this->getSource(), $this->getTarget())];
+    }
+
+    private function getDependencyName(): string
+    {
+        return 'Mapper_'.$this->getSource().'_'.$this->getTarget();
+    }
+
+    private function getSource(): string
+    {
+        $sourceTypeName = 'array';
+
+        if (Type::BUILTIN_TYPE_OBJECT === $this->sourceType->getBuiltinType() && null !== $this->sourceType->getClassName()) {
+            $sourceTypeName = $this->sourceType->getClassName();
+        }
+
+        return $sourceTypeName;
+    }
+
+    private function getTarget(): string
+    {
+        $targetTypeName = 'array';
+
+        if (Type::BUILTIN_TYPE_OBJECT === $this->targetType->getBuiltinType() && null !== $this->targetType->getClassName()) {
+            $targetTypeName = $this->targetType->getClassName();
+        }
+
+        return $targetTypeName;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/ObjectTransformerFactory.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/ObjectTransformerFactory.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\AutoMapperRegistry;
+use Symfony\Component\AutoMapper\AutoMapperRegistryInterface;
+use Symfony\Component\AutoMapper\MapperMetadataInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class ObjectTransformerFactory extends AbstractUniqueTypeTransformerFactory implements PrioritizedTransformerFactoryInterface
+{
+    public function __construct(
+        private readonly AutoMapperRegistryInterface $registry,
+    ) {
+    }
+
+    protected function createTransformer(Type $sourceType, Type $targetType, MapperMetadataInterface $mapperMetadata): ?TransformerInterface
+    {
+        // Only deal with source type being an object or an array that is not a collection
+        if (!$this->isObjectType($sourceType) || !$this->isObjectType($targetType)) {
+            return null;
+        }
+
+        $sourceTypeName = 'array';
+        $targetTypeName = 'array';
+
+        if (Type::BUILTIN_TYPE_OBJECT === $sourceType->getBuiltinType()) {
+            $sourceTypeName = $sourceType->getClassName();
+        }
+
+        if (Type::BUILTIN_TYPE_OBJECT === $targetType->getBuiltinType()) {
+            $targetTypeName = $targetType->getClassName();
+        }
+
+        if (null !== $sourceTypeName && null !== $targetTypeName && $this->registry->hasMapper($sourceTypeName, $targetTypeName)) {
+            return new ObjectTransformer($sourceType, $targetType);
+        }
+
+        return null;
+    }
+
+    private function isObjectType(Type $type): bool
+    {
+        if (!\in_array($type->getBuiltinType(), [Type::BUILTIN_TYPE_OBJECT, Type::BUILTIN_TYPE_ARRAY])) {
+            return false;
+        }
+
+        if (Type::BUILTIN_TYPE_ARRAY === $type->getBuiltinType() && $type->isCollection()) {
+            return false;
+        }
+
+        if (is_subclass_of($type->getClassName(), \UnitEnum::class)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function getPriority(): int
+    {
+        return 2;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/PrioritizedTransformerFactoryInterface.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/PrioritizedTransformerFactoryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+interface PrioritizedTransformerFactoryInterface
+{
+    /**
+     * TransformerFactory priority.
+     */
+    public function getPriority(): int;
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/SourceEnumTransformer.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/SourceEnumTransformer.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\Generator\UniqueVariableScope;
+use PhpParser\Node\Expr;
+
+/**
+ * Transform a BackendEnum into a scalar.
+ *
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class SourceEnumTransformer implements TransformerInterface
+{
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        return [new Expr\PropertyFetch($input, 'value'), []];
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/StringToDateTimeTransformer.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/StringToDateTimeTransformer.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\Generator\UniqueVariableScope;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+
+/**
+ * Transform a string to a \DateTimeInterface object.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class StringToDateTimeTransformer implements TransformerInterface
+{
+    public function __construct(
+        private readonly string $className,
+        private readonly string $format = \DateTimeInterface::RFC3339,
+    ) {
+    }
+
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        $className = \DateTimeInterface::class === $this->className ? \DateTimeImmutable::class : $this->className;
+
+        return [new Expr\StaticCall(new Name\FullyQualified($className), 'createFromFormat', [
+            new Arg(new String_($this->format)),
+            new Arg($input),
+        ]), []];
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/StringToSymfonyUidTransformer.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/StringToSymfonyUidTransformer.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\Generator\UniqueVariableScope;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+
+/**
+ * Transform a string to a Symfony Uid object.
+ *
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class StringToSymfonyUidTransformer implements TransformerInterface
+{
+    public function __construct(
+        private readonly string $className,
+    ) {
+    }
+
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        return [
+            new Expr\New_(new Name($this->className), [new Arg($input)]),
+            [],
+        ];
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/SymfonyUidCopyTransformer.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/SymfonyUidCopyTransformer.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\Generator\UniqueVariableScope;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Transform Symfony Uid to the same object.
+ *
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class SymfonyUidCopyTransformer implements TransformerInterface
+{
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        return [
+            new Expr\Ternary(
+                new Expr\Instanceof_($input, new Name(Ulid::class)),
+                new Expr\New_(new Name(Ulid::class), [new Arg(new Expr\MethodCall($input, 'toBase32'))]),
+                new Expr\New_(new Name(Uuid::class), [new Arg(new Expr\MethodCall($input, 'toRfc4122'))])
+            ),
+            [],
+        ];
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/SymfonyUidToStringTransformer.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/SymfonyUidToStringTransformer.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\Generator\UniqueVariableScope;
+use PhpParser\Node\Expr;
+
+/**
+ * Transform a \DateTimeInterface object to a string.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class SymfonyUidToStringTransformer implements TransformerInterface
+{
+    public function __construct(
+        private readonly bool $isUlid,
+    ) {
+    }
+
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        if ($this->isUlid) {
+            return [
+                // ulid
+                new Expr\MethodCall($input, 'toBase32'),
+                [],
+            ];
+        }
+
+        return [
+            // uuid
+            new Expr\MethodCall($input, 'toRfc4122'),
+            [],
+        ];
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/SymfonyUidTransformerFactory.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/SymfonyUidTransformerFactory.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\MapperMetadataInterface;
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\Ulid;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class SymfonyUidTransformerFactory extends AbstractUniqueTypeTransformerFactory implements PrioritizedTransformerFactoryInterface
+{
+    /**
+     * @var array<string, array{0: bool, 1: bool}>
+     */
+    private array $reflectionCache = [];
+
+    protected function createTransformer(Type $sourceType, Type $targetType, MapperMetadataInterface $mapperMetadata): ?TransformerInterface
+    {
+        $isSourceUid = $this->isUid($sourceType);
+        $isTargetUid = $this->isUid($targetType);
+
+        if ($isSourceUid && $isTargetUid) {
+            return new SymfonyUidCopyTransformer();
+        }
+
+        if ($isSourceUid) {
+            return new SymfonyUidToStringTransformer($this->reflectionCache[$sourceType->getClassName()][1]);
+        }
+
+        if ($isTargetUid) {
+            return new StringToSymfonyUidTransformer($targetType->getClassName());
+        }
+
+        return null;
+    }
+
+    private function isUid(Type $type): bool
+    {
+        if (Type::BUILTIN_TYPE_OBJECT !== $type->getBuiltinType()) {
+            return false;
+        }
+
+        if (null === $type->getClassName()) {
+            return false;
+        }
+
+        if (!\array_key_exists($type->getClassName(), $this->reflectionCache)) {
+            $reflClass = new \ReflectionClass($type->getClassName());
+            $this->reflectionCache[$type->getClassName()] = [$reflClass->isSubclassOf(AbstractUid::class), Ulid::class === $type->getClassName()];
+        }
+
+        return $this->reflectionCache[$type->getClassName()][0];
+    }
+
+    public function getPriority(): int
+    {
+        return 24;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/TargetEnumTransformer.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/TargetEnumTransformer.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\Generator\UniqueVariableScope;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+
+/**
+ * Transform a scalar into a BackendEnum.
+ *
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class TargetEnumTransformer implements TransformerInterface
+{
+    public function __construct(
+        private readonly string $targetClassName,
+    ) {
+    }
+
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        return [new Expr\StaticCall(new Name\FullyQualified($this->targetClassName), 'from', [
+            new Arg($input),
+        ]), []];
+    }
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/TransformerFactoryInterface.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/TransformerFactoryInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\MapperMetadataInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Create transformer.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+interface TransformerFactoryInterface
+{
+    /**
+     * Get transformer to use when mapping from an array of type to another array of type.
+     *
+     * @param Type[] $sourceTypes
+     * @param Type[] $targetTypes
+     */
+    public function getTransformer(?array $sourceTypes, ?array $targetTypes, MapperMetadataInterface $mapperMetadata): ?TransformerInterface;
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/TransformerInterface.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/TransformerInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\Extractor\PropertyMapping;
+use Symfony\Component\AutoMapper\Generator\UniqueVariableScope;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt;
+
+/**
+ * Transformer tell how to transform a property mapping.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+interface TransformerInterface
+{
+    /**
+     * Get AST output and expressions for transforming a property mapping given an input.
+     *
+     * @return array{0: Expr, 1: Stmt[]} First value is the output expression, second value is an array of stmt needed to get the output
+     */
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array;
+}

--- a/src/Symfony/Component/AutoMapper/Transformer/UniqueTypeTransformerFactory.php
+++ b/src/Symfony/Component/AutoMapper/Transformer/UniqueTypeTransformerFactory.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AutoMapper\Transformer;
+
+use Symfony\Component\AutoMapper\MapperMetadataInterface;
+
+/**
+ * Reduce array of type to only one type on source and target.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class UniqueTypeTransformerFactory implements TransformerFactoryInterface, PrioritizedTransformerFactoryInterface, ChainTransformerFactoryAwareInterface
+{
+    use ChainTransformerFactoryAwareTrait;
+
+    public function getTransformer(?array $sourceTypes, ?array $targetTypes, MapperMetadataInterface $mapperMetadata): ?TransformerInterface
+    {
+        $nbSourceTypes = $sourceTypes ? \count($sourceTypes) : 0;
+        $nbTargetTypes = $targetTypes ? \count($targetTypes) : 0;
+
+        if (null === $sourceTypes || 0 === $nbSourceTypes || $nbSourceTypes > 1) {
+            return null;
+        }
+
+        if (null === $targetTypes || $nbTargetTypes <= 1) {
+            return null;
+        }
+
+        foreach ($targetTypes as $targetType) {
+
+            $transformer = $this->chainTransformerFactory->getTransformer($sourceTypes, [$targetType], $mapperMetadata);
+
+            if (null !== $transformer) {
+                return $transformer;
+            }
+        }
+
+        return null;
+    }
+
+    public function getPriority(): int
+    {
+        return 32;
+    }
+}

--- a/src/Symfony/Component/AutoMapper/composer.json
+++ b/src/Symfony/Component/AutoMapper/composer.json
@@ -1,0 +1,40 @@
+{
+    "name": "symfony/automapper",
+    "type": "library",
+    "description": "Map data from a source to a target",
+    "keywords": [],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Fabien Potencier",
+            "email": "fabien@symfony.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.1",
+        "nikic/php-parser": "^4.0",
+        "symfony/property-info": "^6.0",
+        "symfony/serializer": "^6.0"
+    },
+    "require-dev": {
+        "moneyphp/money": "^4.1",
+        "symfony/http-kernel": "^6.0",
+        "symfony/uid": "^6.0",
+        "symfony/filesystem": "^6.0",
+        "doctrine/annotations": "^2.0",
+        "phpstan/phpdoc-parser": "^1.16",
+        "phpdocumentor/reflection-docblock": "^5.2"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\AutoMapper\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/AutoMapper/phpunit.xml.dist
+++ b/src/Symfony/Component/AutoMapper/phpunit.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony AutoMapper Component Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
+</phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.3
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | todo

This PR brings a new component to Symfony: the AutoMapper. While Symfony's Serializer aims towards flexibility, it lacks performance (you can see https://live.symfony.com/account/replay/video/593 replay for more details about it).
The AutoMapper adds AST to generate blazing fast mappers to replace the Serializer in simple mapping scenarios.

## Description

Taken from https://github.com/AutoMapper/AutoMapper
> AutoMapper is a simple little library built to solve a deceptively complex problem - getting rid of code that mapped one object to another. This type of code is rather dreary and boring to write, so why not invent a tool to do it for us?

In PHP libraries and application mapping from one object to another is fairly common:
- `ObjectNormalizer` / `GetSetMethodNormalizer` in `symfony/serializer`
- Mapping request data to object in `symfony/form`
- Hydrate object from SQL results in Doctrine (You can see https://github.com/soyuka/esql that uses the AutoMapper for the same purpose)
- Migrating legacy data to new model
- Mapping from database model to dto objects (API / CQRS / ...)
- ...

And even [more recently](https://github.com/symfony/symfony/pull/49138) with the `MapQueryString` attribute.

The goal of this component is to offer an abstraction on top of this subject. For that goal it provides an unique interface (other code is only implementation detail):
```php
interface AutoMapperInterface
{
    /**
     * Maps data from a source to a target.
     *
     * @param array|object|null   $source  Any data object, which may be an object or an array
     * @param string|array|object $target  To which type of data, or data, the source should be mapped
     * @param array               $context Mapper context
     *
     * @return array|object|null The mapped object
     */
    public function map(null|array|object $source, string|array|object $target, array $context = []): null|array|object;
}
```
The source is from where the data comes from, it can be either an array or an object.
The target is where the data should be mapped to, it can be either a string (representing a type: array or class name) or directly an array or object (in that case construction of the object is avoided).

Current implementation handle all of those possibilities at the exception of the mapping from a dynamic object (array / stdClass) to another dynamic object (this could be compared to the normalization stack of the Symfony Serializer).

## Usage

Someone who wants to map an object will only have to do this:
```php
// With class name
$target = $automapper->map($source, Foo::class);
// With existing object
$target = new Foo();
$target = $automapper->map($source, $target);
// To an array
$target = $automapper->map($source, 'array');
// From an array
$source = ['a' => 'b'];
$target = $automapper->map($source, Foo::class);
```

## Other features

### Context

Context object allow to pass options for the mapping:
```php
// Using context
$context = new Context();
$target = $automapper->map($source, Foo::class, $context);

// Groups (serializer annotation), will only map value that match those group in source and target
$context = new Context(['groupA', 'groupB']);
// Allowed attributes, will only map specific properties (exclude others), allow nesting for sub mapping like the serializer component
$context = new Context(null, ['propertyA', 'propertyB', 'foo' => ['fooPropertyA']]);
// Ignored attributes, exclude thos propreties include others
$context = new Context(null, null, ['propertyA', 'propertyB', 'foo' => ['fooPropertyA']]);
// Set circular reference limit
$context->setCircularReferenceLimit(2);
// Set circular reference handler
$context->setCircularReferenceHandler(function () { ... });
```

### Private properties

This component map private properties (However this can deactivated).

### Nested Mapping

This component map nested class when it's possible.

### Circular Reference

Default circular reference implementation is to keep them during mapping, which means somethings like:

```php
$foo = new Foo();
$foo->setFoo($foo);

$target = $this->automapper->map($foo, 'array');
```
will produce an array where the foo property will be a reference to the parent.

Having that allow using this component as a DeepCloning service by mapping to the same object:
```php
$foo = new Foo();
$foo->setFoo($foo);

$deepClonedFoo = $this->automapper->map($foo, Foo::class);
```

### Max Depth

This component understand the Max Depth Annotation of the Serializer component and will not map after it's reached.

### Name Converter

Default implementation allows you to pass a Name Converter when converting to or from an array to change the property name used.

### Discriminator Mapping

This component understand the Discriminiator Mapping Annotation of the Serializer component and should correctly handle construction of object when having inheritance.

### Ignored

This component understand the Ignore Annotation of the Serializer component and will not map if a property is flagged.

### Type casting

This component will try to correctly map scalar values (going from int to string, etc ...).

### Readonly properties & classes

This component does support readonly properties & classes. For the readonly classes, you will have an exception by default if you try to map to a readonly class with an object to populate.

### Warmup mappers

If you have a set of critical mappers, you can generate mappers before executing your code on cache warmup thanks to some configuration:
```yaml
framework:
    automapper: 
        enabled: true
        warmup:
            - {source: 'array', target: 'Symfony\Bundle\FrameworkBundle\Tests\Fixtures\AutoMapper\Foo'}
            - {target: 'Symfony\Bundle\FrameworkBundle\Tests\Fixtures\AutoMapper\Bar'}
```

## History

Initial code of this component was done in a library here: https://github.com/janephp/automapper

After some works and talks with @dunglas, @lyrixx and @mtarld I propose this library as a new component for Symfony, which can be used by other components.

## Implementation

Default implementation use code generation for mapping, it reads once the metadata needed to build the mapper then write PHP code, after this, no metadata reading or analysis is done, only the generated mapper is used.

This allow for very fast mapping, here is some benchmarks using the library where the code comes from (`jane-php/automapper`):

![image](https://user-images.githubusercontent.com/944409/233790869-1ed0fa27-c1fe-4a84-9b7e-8bbb8107b0ca.png)

I used PHP 7.4 here because JMS Serializer is not compatible with PHP 8.0+, but this shouldn't change the results that much. Bench code can be found at: https://github.com/Korbeil/automapper-bench

## Normalizer Bridge

A normalizer Bridge is available where its goal is to be 100% feature compatible with the `ObjectNormalizer` of the symfony/serializer component. The goal of this bridge is not to replace the `ObjectNormalizer` but rather providing a very fast alternative.

As shown in the benchmark above, using this bridge leads up to more than 8x speed increase in normalization.

## Things that needs to be done

This PR should be mostly readly in terms of code and functionnalities for a first stage, however there is still some things to be done:
- Documentation: documentation explaining this new component (will be done once the main interface and usage is ok).
- Support all Serializer attributes for a complete compatibility.

## Future consideration

Things that could be done but not in this PR:
- `symfony/form` bridge for mapping request data to object
- `symfony/framework-bundle` integration
- `symfony/validator` integration:

Feel free to challenge as much as possible