### PR TITLE
Add TypeInfo component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,6 +108,7 @@
         "symfony/translation": "self.version",
         "symfony/twig-bridge": "self.version",
         "symfony/twig-bundle": "self.version",
+        "symfony/type-info": "self.version",
         "symfony/uid": "self.version",
         "symfony/validator": "self.version",
         "symfony/var-dumper": "self.version",

--- a/src/Symfony/Component/PropertyInfo/Type.php
+++ b/src/Symfony/Component/PropertyInfo/Type.php
@@ -40,20 +40,7 @@ class Type
      *
      * @var string[]
      */
-    public static array $builtinTypes = [
-        self::BUILTIN_TYPE_INT,
-        self::BUILTIN_TYPE_FLOAT,
-        self::BUILTIN_TYPE_STRING,
-        self::BUILTIN_TYPE_BOOL,
-        self::BUILTIN_TYPE_RESOURCE,
-        self::BUILTIN_TYPE_OBJECT,
-        self::BUILTIN_TYPE_ARRAY,
-        self::BUILTIN_TYPE_CALLABLE,
-        self::BUILTIN_TYPE_FALSE,
-        self::BUILTIN_TYPE_TRUE,
-        self::BUILTIN_TYPE_NULL,
-        self::BUILTIN_TYPE_ITERABLE,
-    ];
+    public static array $builtinTypes = BaseType::BUILTIN_TYPES;
 
     /**
      * List of PHP builtin collection types.
@@ -73,7 +60,14 @@ class Type
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(string $builtinType, bool $nullable = false, string $class = null, bool $collection = false, array|Type $collectionKeyType = null, array|Type $collectionValueType = null)
+    public function __construct(
+        string $builtinType,
+        bool $nullable = false,
+        string $class = null,
+        bool $collection = false,
+        array|Type $collectionKeyType = null,
+        array|Type $collectionValueType = null,
+    )
     {
         if (null !== $collectionKeyType && !is_array($collectionKeyType)) {
             $collectionKeyType = [$collectionKeyType];

--- a/src/Symfony/Component/TypeInfo/.gitattributes
+++ b/src/Symfony/Component/TypeInfo/.gitattributes
@@ -1,0 +1,4 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Component/TypeInfo/.gitignore
+++ b/src/Symfony/Component/TypeInfo/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/TypeInfo/CHANGELOG.md
+++ b/src/Symfony/Component/TypeInfo/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+7.0
+---
+
+ * Added component

--- a/src/Symfony/Component/TypeInfo/CompositeTypeTrait.php
+++ b/src/Symfony/Component/TypeInfo/CompositeTypeTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Symfony\Component\TypeInfo;
+
+use Symfony\Component\TypeInfo\Exception\LogicException;
+
+/**
+ * @internal
+ */
+trait CompositeTypeTrait
+{
+    /**
+     * @param callable(Type): bool $callable
+     */
+    private function atLeastOneTypeIs(callable $callable): bool
+    {
+        return count(array_filter($callable, $this->types));
+    }
+
+    /**
+     * @param callable(Type): bool $callable
+     */
+    private function everyTypeIs(callable $callable): bool
+    {
+        foreach ($this->types as $t) {
+            if (false === $callable($t)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function createUnhandledException(string $method): LogicException
+    {
+        return new LogicException('Cannot call "%s()" on a composite type.', $method);
+    }
+}

--- a/src/Symfony/Component/TypeInfo/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/TypeInfo/Exception/ExceptionInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\TypeInfo\Exception;
+
+/**
+ * Base exception interface.
+ */
+interface ExceptionInterface extends \Throwable
+{
+}

--- a/src/Symfony/Component/TypeInfo/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/TypeInfo/Exception/ExceptionInterface.php
@@ -2,9 +2,6 @@
 
 namespace Symfony\Component\TypeInfo\Exception;
 
-/**
- * Base exception interface.
- */
 interface ExceptionInterface extends \Throwable
 {
 }

--- a/src/Symfony/Component/TypeInfo/Exception/InvalidArgumentException.php
+++ b/src/Symfony/Component/TypeInfo/Exception/InvalidArgumentException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\TypeInfo\Exception;
+
+/**
+ * InvalidArgumentException
+ */
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/TypeInfo/Exception/InvalidArgumentException.php
+++ b/src/Symfony/Component/TypeInfo/Exception/InvalidArgumentException.php
@@ -2,9 +2,6 @@
 
 namespace Symfony\Component\TypeInfo\Exception;
 
-/**
- * InvalidArgumentException
- */
 class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {
 }

--- a/src/Symfony/Component/TypeInfo/Exception/LogicException.php
+++ b/src/Symfony/Component/TypeInfo/Exception/LogicException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\TypeInfo\Exception;
+
+class LogicException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/TypeInfo/GenericType.php
+++ b/src/Symfony/Component/TypeInfo/GenericType.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Symfony\Component\TypeInfo;
+
+use Symfony\Component\TypeInfo\Exception\LogicException;
+
+final readonly class GenericType extends Type
+{
+    /**
+     * @var list<Type>
+     */
+    private array $parameterTypes;
+
+    private string $stringRepresentation;
+
+    public function __construct(
+        private Type $mainType,
+        Type ...$parameterTypes,
+    ) {
+        parent::__construct($mainType);
+
+        $parameterTypesStringRepresentation = '';
+        $glue = '';
+        foreach ($parameterTypes as $t) {
+            $parameterTypesStringRepresentation .= $glue.((string) $t);
+            $glue = ', ';
+        }
+
+        $this->stringRepresentation = ((string) $mainType).'<'.$parameterTypesStringRepresentation.'>';
+        $this->parameterTypes = $parameterTypes;
+    }
+
+    /**
+     * @return list<Type>
+     */
+    public function getParametersType(): array
+    {
+        return $this->parameterTypes;
+    }
+
+    /**
+     * @throws LogicException
+     */
+    public function getCollectionKeyType(): self
+    {
+        if (!$this->isCollection()) {
+            throw new LogicException(sprintf('Cannot get collection key type on "%s" type as it\'s not a collection.', (string) $this));
+        }
+
+        return match (\count($this->parameterTypes)) {
+            2 => $this->parameterTypes[0],
+            1 => new Type(builtinType: self::BUILTIN_TYPE_INT),
+            default => parent::getCollectionKeyType(),
+        };
+    }
+
+    /**
+     * @throws LogicException
+     */
+    public function getCollectionValueType(): self
+    {
+        if (!$this->isCollection()) {
+            throw new LogicException(sprintf('Cannot get collection value type on "%s" type as it\'s not a collection.', (string) $this));
+        }
+
+        return match (\count($this->parameterTypes)) {
+            2 => $this->parameterTypes[1],
+            1 => $this->parameterTypes[0],
+            default => parent::getCollectionValueType(),
+        };
+    }
+
+    public function __toString(): string
+    {
+        return $this->stringRepresentation;
+    }
+}

--- a/src/Symfony/Component/TypeInfo/IntersectionType.php
+++ b/src/Symfony/Component/TypeInfo/IntersectionType.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Symfony\Component\TypeInfo;
+
+use Symfony\Component\TypeInfo\Exception\LogicException;
+
+final readonly class IntersectionType extends Type
+{
+    use CompositeTypeTrait;
+
+    /**
+     * @var list<Type>
+     */
+    private array $types;
+
+    private string $stringRepresentation;
+
+    public function __construct(Type ...$types)
+    {
+        $this->types = $types;
+
+        $stringRepresentation = '';
+        $glue = '';
+        foreach ($this->types as $t) {
+            $stringRepresentation .= $glue.((string) $t);
+            $glue = '&';
+        }
+
+        $this->stringRepresentation = $stringRepresentation;
+    }
+
+    /**
+     * @return list<Type>
+     */
+    public function getTypes(): array
+    {
+        return $this->types;
+    }
+
+    public function getBuiltinType(): string
+    {
+        throw $this->createUnhandledException(__METHOD__);
+    }
+
+    public function isNullable(): bool
+    {
+        return $this->everyTypeIs(fn (Type $t): bool => $t->isNullable());
+    }
+
+    public function isScalar(): bool
+    {
+        throw $this->createUnhandledException(__METHOD__);
+    }
+
+    public function isObject(): bool
+    {
+        return $this->everyTypeIs(fn (Type $t): bool => $t->isObject());
+    }
+
+    public function getClassName(): string
+    {
+        throw $this->createUnhandledException(__METHOD__);
+    }
+
+    public function isEnum(): bool
+    {
+        throw $this->createUnhandledException(__METHOD__);
+    }
+
+    public function isBackedEnum(): bool
+    {
+        throw $this->createUnhandledException(__METHOD__);
+    }
+
+    public function getEnumBackingType(): self
+    {
+        throw $this->createUnhandledException(__METHOD__);
+    }
+
+    public function isCollection(): bool
+    {
+        throw $this->createUnhandledException(__METHOD__);
+    }
+
+    public function getCollectionKeyType(): self
+    {
+        throw $this->createUnhandledException(__METHOD__);
+    }
+
+    public function getCollectionValueType(): self
+    {
+        throw $this->createUnhandledException(__METHOD__);
+    }
+
+    public function isList(): bool
+    {
+        return $this->everyTypeIs(fn (Type $t): bool => $t->isList());
+    }
+
+    public function isDict(): bool
+    {
+        return $this->everyTypeIs(fn (Type $t): bool => $t->isDict());
+    }
+
+    public function __toString(): string
+    {
+        return $this->stringRepresentation;
+    }
+}

--- a/src/Symfony/Component/TypeInfo/LICENSE
+++ b/src/Symfony/Component/TypeInfo/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2015-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/TypeInfo/README.md
+++ b/src/Symfony/Component/TypeInfo/README.md
@@ -1,0 +1,14 @@
+TypeInfo Component
+======================
+
+The TypeInfo component extracts information about PHP class' types using
+metadata of popular sources.
+
+Resources
+---------
+
+ * [Documentation](https://symfony.com/doc/current/components/type_info.html)
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/symfony/issues) and
+   [send Pull Requests](https://github.com/symfony/symfony/pulls)
+   in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/TypeInfo/Type.php
+++ b/src/Symfony/Component/TypeInfo/Type.php
@@ -58,6 +58,7 @@ readonly class Type implements \Stringable
         ?string $builtinType = null,
         ?string $className = null,
         ?self $enumBackingType = null,
+        ?bool $isCollection = null,
     ) {
         $isCollection = false;
         $isEnum = $isBackedEnum = false;
@@ -86,8 +87,8 @@ readonly class Type implements \Stringable
             $isBackedEnum = true;
         }
 
-        if (in_array($builtinType, [self::BUILTIN_TYPE_ARRAY, self::BUILTIN_TYPE_ITERABLE])) {
-            $isCollection = true;
+        if (null === $isCollection) {
+            $isCollection = in_array($builtinType, [self::BUILTIN_TYPE_ARRAY, self::BUILTIN_TYPE_ITERABLE]);
         }
 
         $this->builtinType = $builtinType;

--- a/src/Symfony/Component/TypeInfo/Type.php
+++ b/src/Symfony/Component/TypeInfo/Type.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Symfony\Component\TypeInfo;
+
+use Symfony\Component\TypeInfo\Exception\InvalidArgumentException;
+
+class Type
+{
+    public const BUILTIN_TYPE_INT = 'int';
+    public const BUILTIN_TYPE_FLOAT = 'float';
+    public const BUILTIN_TYPE_STRING = 'string';
+    public const BUILTIN_TYPE_BOOL = 'bool';
+    public const BUILTIN_TYPE_RESOURCE = 'resource';
+    public const BUILTIN_TYPE_OBJECT = 'object';
+    public const BUILTIN_TYPE_ARRAY = 'array';
+    public const BUILTIN_TYPE_MIXED = 'mixed';
+    public const BUILTIN_TYPE_NULL = 'null';
+    public const BUILTIN_TYPE_FALSE = 'false';
+    public const BUILTIN_TYPE_TRUE = 'true';
+    public const BUILTIN_TYPE_CALLABLE = 'callable';
+    public const BUILTIN_TYPE_ITERABLE = 'iterable';
+
+    /**
+     * List of PHP builtin types.
+     *
+     * @var string[]
+     */
+    public static array $builtinTypes = [
+        self::BUILTIN_TYPE_INT,
+        self::BUILTIN_TYPE_FLOAT,
+        self::BUILTIN_TYPE_STRING,
+        self::BUILTIN_TYPE_BOOL,
+        self::BUILTIN_TYPE_RESOURCE,
+        self::BUILTIN_TYPE_OBJECT,
+        self::BUILTIN_TYPE_ARRAY,
+        self::BUILTIN_TYPE_CALLABLE,
+        self::BUILTIN_TYPE_FALSE,
+        self::BUILTIN_TYPE_TRUE,
+        self::BUILTIN_TYPE_NULL,
+        self::BUILTIN_TYPE_ITERABLE,
+        self::BUILTIN_TYPE_MIXED,
+    ];
+
+    /**
+     * List of PHP builtin collection types.
+     *
+     * @var string[]
+     */
+    public static array $builtinCollectionTypes = [
+        self::BUILTIN_TYPE_ARRAY,
+        self::BUILTIN_TYPE_ITERABLE,
+    ];
+
+    private bool $collection = false;
+    private bool $enum = false;
+
+    public function __construct(
+        private ?string $builtinType = null,
+        private readonly ?string $className = null,
+        private readonly array $genericParameterTypes = [],
+        private readonly array $unionTypes = [],
+        private readonly array $intersectionTypes = [],
+        private readonly ?self $enumBackingType = null,
+    ) {
+        if (!\in_array($builtinType, self::$builtinTypes)) {
+            throw new InvalidArgumentException(sprintf('"%s" is not a valid PHP type.', $builtinType));
+        }
+
+        if (1 === \count($this->unionTypes)) {
+            throw new InvalidArgumentException(sprintf('Cannot define only one union type for "%s" type.', $this->builtinType));
+        }
+
+        if (1 === \count($this->intersectionTypes)) {
+            throw new InvalidArgumentException(sprintf('Cannot define only one intersection type for "%s" type.', $this->builtinType));
+        }
+
+        if (null !== $this->className) {
+            $this->builtinType = self::BUILTIN_TYPE_OBJECT;
+        }
+
+        if (in_array($this->builtinType, self::$builtinCollectionTypes)) {
+            $this->collection = true;
+        }
+
+        if (is_subclass_of($className, \UnitEnum::class)) {
+            $this->enum = true;
+        }
+    }
+
+    /**
+     * Gets built-in type.
+     *
+     * Can be bool, int, float, string, array, object, resource, null, callback or iterable.
+     */
+    public function getBuiltinType(): string
+    {
+        return $this->builtinType;
+    }
+
+    public function isNullable(): bool
+    {
+        return self::BUILTIN_TYPE_NULL === $this->builtinType || (\count($this->unionTypes) > 0 && in_array(self::BUILTIN_TYPE_NULL, $this->unionTypes));
+    }
+
+    /**
+     * Gets the class name.
+     *
+     * Only applicable if the built-in type is object.
+     */
+    public function getClassName(): ?string
+    {
+        return $this->className;
+    }
+
+    public function isCollection(): bool
+    {
+        return $this->collection;
+    }
+
+    public function isEnum(): bool
+    {
+        return $this->enum;
+    }
+
+    public function getEnumBackingType(): ?self
+    {
+        return $this->enumBackingType;
+    }
+
+    /**
+     * Gets collection key types.
+     *
+     * Only applicable for a collection type.
+     *
+     * @return Type[]
+     */
+    public function getCollectionKeyTypes(): array
+    {
+        if (!$this->collection) {
+            return [];
+        }
+
+        if (\count($this->genericParameterTypes) > 1) {
+            return $this->genericParameterTypes[0];
+        }
+
+        return [new self(self::BUILTIN_TYPE_INT)];
+    }
+
+    /**
+     * Gets collection value types.
+     *
+     * Only applicable for a collection type.
+     *
+     * @return Type[]
+     */
+    public function getCollectionValueTypes(): array
+    {
+        if (!$this->collection) {
+            return [];
+        }
+
+        $genericParameterTypesCount = \count($this->genericParameterTypes);
+
+        return match ($genericParameterTypesCount) {
+            2 => [$this->genericParameterTypes[1]],
+            1 => [$this->genericParameterTypes[0]],
+            default => [new self(self::BUILTIN_TYPE_MIXED)],
+        };
+    }
+}

--- a/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
+++ b/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Symfony\Component\TypeInfo;
+
+use Symfony\Component\TypeInfo\Exception\InvalidArgumentException;
+use Symfony\Component\TypeInfo\Exception\LogicException;
+
+trait TypeFactoryTrait
+{
+    public static function int(bool $nullable = false): Type
+    {
+        $type = new Type(Type::BUILTIN_TYPE_INT);
+        if ($nullable) {
+            return new UnionType(new Type(self::BUILTIN_TYPE_NULL), $type);
+        }
+
+        return $type;
+    }
+
+    public static function float(bool $nullable = false): Type
+    {
+        $type = new Type(Type::BUILTIN_TYPE_FLOAT);
+        if ($nullable) {
+            return new UnionType(new Type(self::BUILTIN_TYPE_NULL), $type);
+        }
+
+        return $type;
+    }
+
+    public static function string(bool $nullable = false): Type
+    {
+        $type = new Type(Type::BUILTIN_TYPE_STRING);
+        if ($nullable) {
+            return new UnionType(new Type(self::BUILTIN_TYPE_NULL), $type);
+        }
+
+        return $type;
+    }
+
+    public static function bool(bool $nullable = false): Type
+    {
+        $type = new Type(Type::BUILTIN_TYPE_BOOL);
+        if ($nullable) {
+            return new UnionType(new Type(self::BUILTIN_TYPE_NULL), $type);
+        }
+
+        return $type;
+    }
+
+    public static function resource(bool $nullable = false): Type
+    {
+        $type = new Type(Type::BUILTIN_TYPE_RESOURCE);
+        if ($nullable) {
+            return new UnionType(new Type(self::BUILTIN_TYPE_NULL), $type);
+        }
+
+        return $type;
+    }
+
+    public static function object(bool $nullable = false): Type
+    {
+        $type = new Type(Type::BUILTIN_TYPE_OBJECT);
+        if ($nullable) {
+            return new UnionType(new Type(self::BUILTIN_TYPE_NULL), $type);
+        }
+
+        return $type;
+    }
+
+    public static function false(bool $nullable = false): Type
+    {
+        $type = new Type(Type::BUILTIN_TYPE_FALSE);
+        if ($nullable) {
+            return new UnionType(new Type(self::BUILTIN_TYPE_NULL), $type);
+        }
+
+        return $type;
+    }
+
+    public static function true(bool $nullable = false): Type
+    {
+        $type = new Type(Type::BUILTIN_TYPE_TRUE);
+        if ($nullable) {
+            return new UnionType(new Type(self::BUILTIN_TYPE_NULL), $type);
+        }
+
+        return $type;
+    }
+
+    public static function callable(bool $nullable = false): Type
+    {
+        $type = new Type(Type::BUILTIN_TYPE_CALLABLE);
+        if ($nullable) {
+            return new UnionType(new Type(self::BUILTIN_TYPE_NULL), $type);
+        }
+
+        return $type;
+    }
+
+    public static function mixed(): Type
+    {
+        return new Type(Type::BUILTIN_TYPE_MIXED);
+    }
+
+    public static function null(): Type
+    {
+        return new Type(Type::BUILTIN_TYPE_NULL);
+    }
+
+    public static function array(Type $value = null, Type $key = null, bool $nullable = false): Type
+    {
+        $mainType = new Type(Type::BUILTIN_TYPE_ARRAY, $nullable);
+        if ($nullable) {
+            $mainType = new UnionType(new Type(self::BUILTIN_TYPE_NULL), $mainType);
+        }
+
+        if (null === $value && null === $key)  {
+            return $mainType;
+        }
+
+        return new GenericType(
+            $mainType,
+            $key ?? self::union(self::int(), self::string()),
+            $value ?? self::mixed(),
+        );
+    }
+
+    public static function list(Type $value = null, bool $nullable = false): Type
+    {
+        return self::array($value, self::int(), $nullable);
+    }
+
+    public static function dict(Type $value = null, bool $nullable = false): Type
+    {
+        return self::array($value, self::string(), $nullable);
+    }
+
+    public static function iterable(bool $nullable = false): Type
+    {
+        $mainType = new Type(Type::BUILTIN_TYPE_ITERABLE, $nullable);
+        if ($nullable) {
+            $mainType = new UnionType(new Type(self::BUILTIN_TYPE_NULL), $mainType);
+        }
+
+        if (null === $value && null === $key)  {
+            return $mainType;
+        }
+
+        return new GenericType(
+            $mainType,
+            $key ?? self::union(self::int(), self::string()),
+            $value ?? self::mixed(),
+        );
+    }
+
+    public static function iterableList(Type $value = null, bool $nullable = false): Type
+    {
+        return self::iterable($value, self::int(), $nullable);
+    }
+
+    public static function iterableDict(Type $value = null, bool $nullable = false): Type
+    {
+        return self::iterable($value, self::string(), $nullable);
+    }
+
+    /**
+     * @param class-string $className
+     */
+    public static function class(string $className, bool $nullable = false): self
+    {
+        $type = new Type(className: $className);
+        if ($nullable) {
+            return new UnionType(new Type(self::BUILTIN_TYPE_NULL), $type);
+        }
+
+        return $type;
+    }
+
+    public static function enum(string $enumClassName, Type $backingType = null, bool $nullable = false): self
+    {
+        $type = new Type(className: $className, enumBackingType: $backingType);
+        if ($nullable) {
+            return new UnionType(new Type(self::BUILTIN_TYPE_NULL), $type);
+        }
+
+        return $type;
+    }
+
+    public static function generic(Type $mainType, self ...$parametersType): self
+    {
+        return new GenericType($mainType, ...$parametersType);
+    }
+
+    public static function union(self ...$types): self
+    {
+        return new UnionType(...$this->types);
+    }
+
+    public static function intersection(self ...$types): self
+    {
+        return new IntersectionType(...$this->types);
+    }
+}

--- a/src/Symfony/Component/TypeInfo/UnionType.php
+++ b/src/Symfony/Component/TypeInfo/UnionType.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Symfony\Component\TypeInfo;
+
+use Symfony\Component\TypeInfo\Exception\LogicException;
+
+final readonly class UnionType extends Type
+{
+    use CompositeTypeTrait;
+
+    /**
+     * @var list<Type>
+     */
+    private array $types;
+
+    private string $stringRepresentation;
+
+    public function __construct(Type ...$types)
+    {
+        $this->types = $types;
+
+        $stringRepresentation = '';
+        $glue = '';
+        foreach ($this->types as $t) {
+            $stringRepresentation .= $glue.((string) $t);
+            $glue = '|';
+        }
+
+        $this->stringRepresentation = $stringRepresentation;
+    }
+
+    /**
+     * @return list<Type>
+     */
+    public function getTypes(): array
+    {
+        return $this->types;
+    }
+
+    public function getBuiltinType(): string
+    {
+        throw $this->createUnhandledException(__METHOD__);
+    }
+
+    public function isNullable(): bool
+    {
+        return $this->atLeastOneTypeIs(fn (Type $t): bool => $t->isNullable());
+    }
+
+    public function isScalar(): bool
+    {
+        return $this->everyTypeIs(fn (Type $t): bool => $t->isScalar());
+    }
+
+    public function isObject(): bool
+    {
+        return $this->everyTypeIs(fn (Type $t): bool => $t->isObject());
+    }
+
+    public function getClassName(): string
+    {
+        throw $this->createUnhandledException(__METHOD__);
+    }
+
+    public function isEnum(): bool
+    {
+        return $this->everyTypeIs(fn (Type $t): bool => $t->isEnum());
+    }
+
+    public function isBackedEnum(): bool
+    {
+        return $this->everyTypeIs(fn (Type $t): bool => $t->isBackedEnum());
+    }
+
+    public function getEnumBackingType(): self
+    {
+        throw $this->createUnhandledException(__METHOD__);
+    }
+
+    public function isCollection(): bool
+    {
+        return $this->everyTypeIs(fn (Type $t): bool => $t->isCollection());
+    }
+
+    public function getCollectionKeyType(): self
+    {
+        throw $this->createUnhandledException(__METHOD__);
+    }
+
+    public function getCollectionValueType(): self
+    {
+        throw $this->createUnhandledException(__METHOD__);
+    }
+
+    public function isList(): bool
+    {
+        return $this->everyTypeIs(fn (Type $t): bool => $t->isList());
+    }
+
+    public function isDict(): bool
+    {
+        return $this->everyTypeIs(fn (Type $t): bool => $t->isDict());
+    }
+
+    public function __toString(): string
+    {
+        return $this->stringRepresentation;
+    }
+}

--- a/src/Symfony/Component/TypeInfo/composer.json
+++ b/src/Symfony/Component/TypeInfo/composer.json
@@ -1,0 +1,40 @@
+{
+    "name": "symfony/type-info",
+    "type": "library",
+    "description": "TODO",
+    "keywords": [
+        "type",
+        "phpdoc",
+        "symfony"
+    ],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Mathias Arlaud",
+            "email": "mathias.arlaud@gmail.com"
+        },
+        {
+            "name": "Baptiste LEDUC",
+            "email": "baptiste.leduc@gmail.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.2"
+    },
+    "require-dev": {
+        "phpdocumentor/reflection-docblock": "^5.2",
+        "phpstan/phpdoc-parser": "^1.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\TypeInfo\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/TypeInfo/phpunit.xml.dist
+++ b/src/Symfony/Component/TypeInfo/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+        >
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Type Info Component Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
+</phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #45071
| License       | MIT

This PR introduces TypeInfo component to improve the compatibility of Symfony with more advance type mappings !
PropertyInfo component does limit types to the linked property they have where type are more rich.

That's why we think a new component is required in order to help that: TypeInfo
